### PR TITLE
Avoid null dereference to mf_calc in BCs

### DIFF
--- a/Source/BoundaryConditions/REMORA_BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/REMORA_BoundaryConditions_cons.cpp
@@ -55,6 +55,17 @@ void REMORAPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box
     bool is_periodic_in_x = geomdata.isPeriodic(0);
     bool is_periodic_in_y = geomdata.isPeriodic(1);
     const Real eps= Real(1.0e-20);
+    const bool have_calc = calc_arr.ok();
+
+    for (int n=0; n < ncomp; ++n) {
+        for (int d=0; d < AMREX_SPACEDIM; ++d) {
+            if ((bc_ptr[n].lo(d) == REMORABCType::orlanski_rad ||
+                bc_ptr[n].hi(d) == REMORABCType::orlanski_rad) &&
+                    !have_calc) {
+                Abort("Requested radiation boundary condition but calc_arr is not defined");
+            }
+        }
+    }
 
     // If we're doing zeta, then calc_arr only has a single component
     // corresponding to the component to be used in calculating the boundary

--- a/Source/BoundaryConditions/REMORA_BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/REMORA_BoundaryConditions_cons.cpp
@@ -49,6 +49,7 @@ void REMORAPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box
     std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
 #endif
     const amrex::BCRec* bc_ptr = bcrs_d.data();
+    const amrex::BCRec* bc_ptr_host = bcrs.data();
     const auto* bc_extdir_vals_ptr = m_bc_extdir_vals_d.data();
 
     GeometryData const& geomdata = m_geom.data();
@@ -59,8 +60,8 @@ void REMORAPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box
 
     for (int n=0; n < ncomp; ++n) {
         for (int d=0; d < AMREX_SPACEDIM; ++d) {
-            if ((bc_ptr[n].lo(d) == REMORABCType::orlanski_rad ||
-                bc_ptr[n].hi(d) == REMORABCType::orlanski_rad) &&
+            if ((bc_ptr_host[n].lo(d) == REMORABCType::orlanski_rad ||
+                bc_ptr_host[n].hi(d) == REMORABCType::orlanski_rad) &&
                     !have_calc) {
                 Abort("Requested radiation boundary condition but calc_arr is not defined");
             }

--- a/Source/BoundaryConditions/REMORA_BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/REMORA_BoundaryConditions_xvel.cpp
@@ -49,7 +49,17 @@ void REMORAPhysBCFunct::impose_xvel_bcs (const Array4<Real>& dest_arr, const Box
     bool is_periodic_in_x = geomdata.isPeriodic(0);
     bool is_periodic_in_y = geomdata.isPeriodic(1);
     const Real eps= Real(1.0e-20);
+    const bool have_calc = calc_arr.ok();
 
+    for (int n=0; n < ncomp; ++n) {
+        for (int d=0; d < AMREX_SPACEDIM; ++d) {
+            if ((bc_ptr[n].lo(d) == REMORABCType::orlanski_rad ||
+                bc_ptr[n].hi(d) == REMORABCType::orlanski_rad) &&
+                    !have_calc) {
+                Abort("Requested radiation boundary condition but calc_arr is not defined");
+            }
+        }
+    }
 
     Box dest_arr_box = growHi(convert(Box(dest_arr),IntVect(1,0,0)),0,-1);
     // First do all ext_dir bcs

--- a/Source/BoundaryConditions/REMORA_BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/REMORA_BoundaryConditions_xvel.cpp
@@ -43,6 +43,7 @@ void REMORAPhysBCFunct::impose_xvel_bcs (const Array4<Real>& dest_arr, const Box
     std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
 #endif
     const amrex::BCRec* bc_ptr = bcrs_d.data();
+    const amrex::BCRec* bc_ptr_host = bcrs.data();
     const auto* bc_extdir_vals_ptr = m_bc_extdir_vals_d.data();
 
     GeometryData const& geomdata = m_geom.data();
@@ -53,8 +54,9 @@ void REMORAPhysBCFunct::impose_xvel_bcs (const Array4<Real>& dest_arr, const Box
 
     for (int n=0; n < ncomp; ++n) {
         for (int d=0; d < AMREX_SPACEDIM; ++d) {
-            if ((bc_ptr[n].lo(d) == REMORABCType::orlanski_rad ||
-                bc_ptr[n].hi(d) == REMORABCType::orlanski_rad) &&
+            // Do this check on the host
+            if ((bc_ptr_host[n].lo(d) == REMORABCType::orlanski_rad ||
+                bc_ptr_host[n].hi(d) == REMORABCType::orlanski_rad) &&
                     !have_calc) {
                 Abort("Requested radiation boundary condition but calc_arr is not defined");
             }

--- a/Source/BoundaryConditions/REMORA_BoundaryConditions_yvel.cpp
+++ b/Source/BoundaryConditions/REMORA_BoundaryConditions_yvel.cpp
@@ -43,6 +43,7 @@ void REMORAPhysBCFunct::impose_yvel_bcs (const Array4<Real>& dest_arr, const Box
     std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
 #endif
     const amrex::BCRec* bc_ptr = bcrs_d.data();
+    const amrex::BCRec* bc_ptr_host = bcrs.data();
     const auto* bc_extdir_vals_ptr = m_bc_extdir_vals_d.data();
 
     GeometryData const& geomdata = m_geom.data();
@@ -54,8 +55,8 @@ void REMORAPhysBCFunct::impose_yvel_bcs (const Array4<Real>& dest_arr, const Box
 
     for (int n=0; n < ncomp; ++n) {
         for (int d=0; d < AMREX_SPACEDIM; ++d) {
-            if ((bc_ptr[n].lo(d) == REMORABCType::orlanski_rad ||
-                bc_ptr[n].hi(d) == REMORABCType::orlanski_rad) &&
+            if ((bc_ptr_host[n].lo(d) == REMORABCType::orlanski_rad ||
+                bc_ptr_host[n].hi(d) == REMORABCType::orlanski_rad) &&
                     !have_calc) {
                 Abort("Requested radiation boundary condition but calc_arr is not defined");
             }

--- a/Source/BoundaryConditions/REMORA_BoundaryConditions_yvel.cpp
+++ b/Source/BoundaryConditions/REMORA_BoundaryConditions_yvel.cpp
@@ -50,6 +50,18 @@ void REMORAPhysBCFunct::impose_yvel_bcs (const Array4<Real>& dest_arr, const Box
     bool is_periodic_in_y = geomdata.isPeriodic(1);
     const Real eps= Real(1.0e-20);
 
+    const bool have_calc = calc_arr.ok();
+
+    for (int n=0; n < ncomp; ++n) {
+        for (int d=0; d < AMREX_SPACEDIM; ++d) {
+            if ((bc_ptr[n].lo(d) == REMORABCType::orlanski_rad ||
+                bc_ptr[n].hi(d) == REMORABCType::orlanski_rad) &&
+                    !have_calc) {
+                Abort("Requested radiation boundary condition but calc_arr is not defined");
+            }
+        }
+    }
+
     Box dest_arr_box = growHi(convert(Box(dest_arr),IntVect(0,1,0)),1,-1);
     // First do all ext_dir bcs
     if (!is_periodic_in_x or bccomp == BCVars::foextrap_bc(m_ncons))

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -236,22 +236,22 @@ REMORA::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionM
 
 
     // This will fill the temporary MultiFabs with data from previous fine data as well as coarse where needed
-    FillPatch(lev, time, tmp_cons_new, cons_new, BCVars::cons_bc, BdyVars::t,0,true,false);
+    FillPatch(lev, time, tmp_cons_new, cons_new, BCVars::cons_bc, BdyVars::t,0,true,false,0,0,zero,tmp_cons_new);
     FillPatch(lev, time, tmp_xvel_new, xvel_new, xvel_bc(), BdyVars::u,0,true,false,0,0,zero,tmp_xvel_new);
     FillPatch(lev, time, tmp_yvel_new, yvel_new, yvel_bc(), BdyVars::v,0,true,false,0,0,zero,tmp_yvel_new);
     FillPatch(lev, time, tmp_zvel_new, zvel_new, zvel_bc(), BdyVars::null,0,true,false);
-    FillPatch(lev, time, tmp_Zt_avg1_new, GetVecOfPtrs(vec_Zt_avg1), zeta_bc(), BdyVars::null,0,true,false);
+    FillPatch(lev, time, tmp_Zt_avg1_new, GetVecOfPtrs(vec_Zt_avg1), zeta_bc(), BdyVars::null,0,true,false,0,0,zero,tmp_Zt_avg1_new);
 
     for (int icomp=0; icomp<3; icomp++) {
-        FillPatch(lev, time, tmp_ubar_new, GetVecOfPtrs(vec_ubar), ubar_bc(), BdyVars::ubar, icomp,false,false);
-        FillPatch(lev, time, tmp_vbar_new, GetVecOfPtrs(vec_vbar), vbar_bc(), BdyVars::vbar, icomp,false,false);
+        FillPatch(lev, time, tmp_ubar_new, GetVecOfPtrs(vec_ubar), ubar_bc(), BdyVars::ubar, icomp,false,false,0,0,zero,tmp_ubar_new);
+        FillPatch(lev, time, tmp_vbar_new, GetVecOfPtrs(vec_vbar), vbar_bc(), BdyVars::vbar, icomp,false,false,0,0,zero,tmp_vbar_new);
     }
     for (int icomp=0; icomp<2; icomp++) {
-        FillPatch(lev, time, tmp_ru_new, GetVecOfPtrs(vec_ru), xvel_bc(), BdyVars::null, icomp,false,false);
-        FillPatch(lev, time, tmp_rv_new, GetVecOfPtrs(vec_rv), yvel_bc(), BdyVars::null, icomp,false,false);
+        FillPatch(lev, time, tmp_ru_new, GetVecOfPtrs(vec_ru), xvel_bc(), BdyVars::null, icomp,false,false,0,0,zero,tmp_ru_new);
+        FillPatch(lev, time, tmp_rv_new, GetVecOfPtrs(vec_rv), yvel_bc(), BdyVars::null, icomp,false,false,0,0,zero,tmp_rv_new);
         // These might want to have BCVars::ubar_bc and vbar_bc
-        FillPatch(lev, time, tmp_ru2d_new, GetVecOfPtrs(vec_ru2d), xvel_bc(), BdyVars::null, icomp,false,false);
-        FillPatch(lev, time, tmp_rv2d_new, GetVecOfPtrs(vec_rv2d), yvel_bc(), BdyVars::null, icomp,false,false);
+        FillPatch(lev, time, tmp_ru2d_new, GetVecOfPtrs(vec_ru2d), xvel_bc(), BdyVars::null, icomp,false,false,0,0,zero,tmp_ru2d_new);
+        FillPatch(lev, time, tmp_rv2d_new, GetVecOfPtrs(vec_rv2d), yvel_bc(), BdyVars::null, icomp,false,false,0,0,zero,tmp_rv2d_new);
     }
 
     MultiFab::Copy(tmp_cons_old,tmp_cons_new,0,0,ncons,tmp_cons_new.nGrowVect());

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -91,8 +91,11 @@ REMORA::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     FillCoarsePatch(lev, time, zvel_new[lev], zvel_new[lev-1], zvel_bc(), BdyVars::null);
 
     if (lev > hires_grid_level) {
+        // n_not_fill = 1 to match existing bathymetry convention
         FillCoarsePatch(lev, time, vec_h[lev].get(), vec_h[lev-1].get(),
-                        BCVars::cons_bc);
+                        foextrap_periodic_bc(), BdyVars::null, 0, false, 1);
+        FillCoarsePatch(lev, time, vec_h[lev].get(), vec_h[lev-1].get(),
+                        foextrap_periodic_bc(), BdyVars::null, 1, false, 1);
     } else {
         set_bathymetry_averaged_down(lev);
     }
@@ -277,8 +280,8 @@ REMORA::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionM
 
     // Handle bathymetry separately
     if (lev > hires_grid_level) {
-        FillPatch(lev, time, tmp_h, GetVecOfPtrs(vec_h), BCVars::cons_bc, BdyVars::null,0,false,false);
-        FillPatch(lev, time, tmp_h, GetVecOfPtrs(vec_h), BCVars::cons_bc, BdyVars::null,1,false,false);
+        FillPatch(lev, time, tmp_h, GetVecOfPtrs(vec_h), foextrap_periodic_bc(), BdyVars::null,0,false,false);
+        FillPatch(lev, time, tmp_h, GetVecOfPtrs(vec_h), foextrap_periodic_bc(), BdyVars::null,1,false,false);
         std::swap(tmp_h,           *vec_h[lev]);
     } else {
         set_bathymetry_averaged_down(lev);

--- a/Source/REMORA_Tagging.cpp
+++ b/Source/REMORA_Tagging.cpp
@@ -27,7 +27,7 @@ REMORA::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
         if (ref_tags[j].Field() == "tracer" || ref_tags[j].Field() == "temp" ||
             ref_tags[j].Field() == "salt") {
             FillPatch(levc, time, *cons_new[levc], cons_new, BCVars::cons_bc, BdyVars::t,
-                0,true,false);
+                0,true,false,0,0,zero,*cons_new[levc]);
         }
         // This allows dynamic refinement based on the value of the tracer
         if (ref_tags[j].Field() == "tracer")
@@ -38,10 +38,10 @@ REMORA::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
         } else if (ref_tags[j].Field() == "salt") {
             MultiFab::Copy(*mf,*cons_new[levc],Salt_comp,0,1,1);
         } else if (ref_tags[j].Field() == "x_velocity") {
-            FillPatch(levc, time, *xvel_new[levc], xvel_new, xvel_bc(), BdyVars::u,0,true,true);
+            FillPatch(levc, time, *xvel_new[levc], xvel_new, xvel_bc(), BdyVars::u,0,true,true,0,0,zero,*xvel_new[levc]);
             MultiFab::Copy(*mf,*xvel_new[levc],0,0,1,1);
         } else if (ref_tags[j].Field() == "y_velocity") {
-            FillPatch(levc, time, *yvel_new[levc], yvel_new, yvel_bc(), BdyVars::v,0,true,true);
+            FillPatch(levc, time, *yvel_new[levc], yvel_new, yvel_bc(), BdyVars::v,0,true,true,0,0,zero,*yvel_new[levc]);
             MultiFab::Copy(*mf,*yvel_new[levc],0,0,1,1);
         } else if (ref_tags[j].Field() == "z_velocity") {
             FillPatch(levc, time, *zvel_new[levc], zvel_new, zvel_bc(), BdyVars::null,0,true,true);

--- a/Source/TimeIntegration/REMORA_TimeStepML.cpp
+++ b/Source/TimeIntegration/REMORA_TimeStepML.cpp
@@ -172,8 +172,8 @@ REMORA::timeStepML (Real time, int /*iteration*/)
             FillPatchNoBC(lev, t_new[lev], *yvel_new[lev], yvel_new, BdyVars::v,0,true,true);
             FillPatchNoBC(lev, t_new[lev], *zvel_new[lev], zvel_new, BdyVars::null,0,true,true);
         } else {
-            FillPatch(lev, t_new[lev], *xvel_new[lev], xvel_new, xvel_bc(), BdyVars::u,0,true,true);
-            FillPatch(lev, t_new[lev], *yvel_new[lev], yvel_new, yvel_bc(), BdyVars::v,0,true,true);
+            FillPatch(lev, t_new[lev], *xvel_new[lev], xvel_new, xvel_bc(), BdyVars::u,0,true,true,0,0,zero,*xvel_new[lev]);
+            FillPatch(lev, t_new[lev], *yvel_new[lev], yvel_new, yvel_bc(), BdyVars::v,0,true,true,0,0,zero,*yvel_new[lev]);
             FillPatch(lev, t_new[lev], *zvel_new[lev], zvel_new, zvel_bc(), BdyVars::null,0,true,true);
         }
     }


### PR DESCRIPTION
- Pass in mf_calc to FillBoundary where it hadn't previously been passed
- Check that if using radiation boundary conditions, mf_calc has been passed