### PR TITLE
Brings `ApplyConservativeRemap` to parity with its ERF-side twin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Keep C++ sources LF-normalized in the repository. Source/REMORA_Coupling.cpp
+# was once committed with CRLF endings (88aae58e3), which made every later diff
+# of it read as a whole-file rewrite. It has since been normalized; this keeps
+# it that way.
+#
+# Deliberately scoped to sources rather than "* text=auto":
+# Docs/sphinx_doc/make.bat legitimately wants CRLF, and the AMReX plotfile gold
+# files under Tests/REMORA_Gold_Files carry a text header over binary payload,
+# which Git's heuristic misreads as text.
+*.cpp text eol=lf
+*.H   text eol=lf
+*.h   text eol=lf

--- a/Source/REMORA_Coupling.cpp
+++ b/Source/REMORA_Coupling.cpp
@@ -119,6 +119,20 @@ StagedSourceBoxArray (const amrex::MultiFab& src,
     return BoxArray(std::move(bl));
 }
 
+// fallback_val fills destination cells that no source cell overlaps.
+//
+// Zero is the wrong default for a physical field: the receiving model cannot tell
+// "no data here" from "the ocean says zero", and for an intensive quantity zero is
+// not merely inaccurate, it drives the receiver's flux formulas outside their valid
+// domain. This mirrors the rationale on the atmosphere->ocean twin at
+// ERF/Source/Coupling/ERF_to_REMORA.cpp:122.
+//
+// The ocean->atmosphere SST lane deliberately leaves this at zero and relies on the
+// per-cell coverage flag instead: where REMORA does not cover an ERF cell, ERF keeps
+// its own wrflowinp SST rather than consuming a value invented here. That is a
+// withholding contract, not a value, so no climatological constant belongs at that
+// call site. The parameter exists because the mask blend below needs it and because
+// other lanes have a meaningful value to pass.
 void
 ApplyConservativeRemap (const amrex::MultiFab& src,
                         amrex::MultiFab& dst,
@@ -126,7 +140,8 @@ ApplyConservativeRemap (const amrex::MultiFab& src,
                         const amrex::iMultiFab& index_mf,
                         int max_stencil_size,
                         const amrex::MultiFab* dst_mask = nullptr,
-                        const amrex::iMultiFab* dst_land_mask = nullptr)
+                        const amrex::iMultiFab* dst_land_mask = nullptr,
+                        amrex::Real fallback_val = amrex::Real(0.0))
 {
     using namespace amrex;
 
@@ -149,12 +164,23 @@ ApplyConservativeRemap (const amrex::MultiFab& src,
         auto        dst_arr = dst.array(mfi);
         const bool has_mask = (dst_mask != nullptr);
         auto const& mask_arr = has_mask ? dst_mask->const_array(mfi) : Array4<const Real>{};
-        // ERF land mask: 1 = land, 0 = water. Destination cells over land are
-        // zeroed out (wet/dry masking only, no vector rotation).
+        // ERF land mask: 0 = water, anything non-zero is land. Destination cells
+        // over land are zeroed out (wet/dry masking only, no vector rotation).
         const bool has_land_mask = (dst_land_mask != nullptr);
         auto const& land_arr = has_land_mask ? dst_land_mask->const_array(mfi) : Array4<const int>{};
 
         ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            // No stencil entry at all means no source cell overlapped this
+            // destination cell. Hand back the fallback rather than an accumulated
+            // zero, and do not apply the masks to it: a masked-out cell still gets
+            // evaluated by the receiving model's flux formulas before the mask is
+            // applied, so it too must hold an admissible value. Mirrors
+            // ERF/Source/Coupling/ERF_to_REMORA.cpp:174.
+            if (idx_arr(i, j, k, 0) < 0) {
+                dst_arr(i, j, k) = fallback_val;
+                return;
+            }
+
             Real sum = 0.0;
             for (int m = 0; m < max_stencil_size; ++m) {
                 Real w = w_arr(i, j, k, m);
@@ -166,8 +192,23 @@ ApplyConservativeRemap (const amrex::MultiFab& src,
                     sum += w * src_arr(src_i, src_j, src_k);
                 }
             }
-            if (has_mask) { sum *= mask_arr(i, j, k); }
-            if (has_land_mask && land_arr(i, j, k) == 1) { sum = Real(0.0); }
+            // Blend toward the fallback rather than multiplying by the mask.
+            // Multiplying drives partially masked cells toward exactly zero, which
+            // is right for a flux lane (fallback_val = 0, so this reduces to
+            // sum *= mask and is bit-identical) but destructive for an intensive
+            // state lane such as SST, where it scales a temperature toward 0 K.
+            // Mirrors ERF/Source/Coupling/ERF_to_REMORA.cpp:202.
+            if (has_mask) {
+                const Real mask = mask_arr(i, j, k);
+                sum = mask * sum + (Real(1.0) - mask) * fallback_val;
+            }
+            // Test against zero, not against 1: ERF stamps lmask = 2 for cells
+            // under ImmersedForcing buildings (ERF/Source/ERF_MakeNewArrays.cpp:890),
+            // so an == 1 test reads every building as water and hands it a remapped
+            // SST. The driver's atmosphere->ocean side already uses the tolerant
+            // form (ERFRemoraMultiBlockContainer.cpp:1767), so == 1 also made the
+            // two directions disagree about the same cell within one timestep.
+            if (has_land_mask && land_arr(i, j, k) != 0) { sum = Real(0.0); }
             dst_arr(i, j, k) = sum;
         });
     }


### PR DESCRIPTION
# Summary of changes
- Add `fallback_val` and a guard for cells with no source stencil
- Blend land mask instead of multiplying, matching the ERF twin
- Relax the land test to `!= 0`, catching ERF's `lmask = 2` cells
- Pin C++ sources to LF so this file cannot revert to CRLF

The call site passes no `fallback_val` on purpose: ocean-to-atmosphere has one
lane, and the atmosphere now keeps its own SST where the ocean does not reach,
so zero there must stay distinguishable from a computed zero.

## What was checked

Three runs, and it is worth being precise about what each one establishes:

- **Builds clean**, with `REMORA_Coupling.cpp` compiling without warnings.
- **`Exec/Upwelling/inputs_twoway`** reaches the ocean-to-atmosphere path and
  produces physical SST (`min 287.146`, `max 287.155`), so the remap still
  works. This is a no-regression check, not a check of the new branches.
- **`erf.is_land = 1`** yields SST 0 everywhere. This is the one that matters
  for the land test: it proves the land branch is genuinely reached, and that
  relaxing `== 1` to `!= 0` leaves the ordinary `lmask == 1` case bit-identical.

With `fallback_val` defaulting to 0, the guard and the blend are provably inert
on every deck available here: the grids are conformal, so no destination cell
lacks a stencil, and `dst_mask` is null on the shipped path. So this PR should
be a no-op on existing cases by construction, which is the intent.

## What was not checked, and how confident to be about it

`lmask == 2` — the one branch that changes behaviour — was **never executed**.
It needs `erf.terrain_type = ImmersedForcing` with real geometry, and no deck in
either repository has that. `erf.is_land = 2` is not a shortcut: ERF rejects it
with "is_land should be 0 or 1".

So the case rests on a source trace, and it is worth separating the parts of it
that are certain from the part that is not:

- **Certain**: the stamp is unconditional on the underlying surface.
  `ERF_MakeNewArrays.cpp:887-890` writes `lmask = 2` wherever
  `terrain_blanking > 0`, with no test for what the cell was before, so it
  overwrites a water cell's `0`.
- **Certain**: the driver passes ERF's raw `iMultiFab` to `PackSurfaceState`
  without converting it, so a `2` arrives here intact, and exact `== 1` reads it
  as water while the driver's own `>= 0.5` test reads it as land.
- **Not established**: that any configuration anyone actually runs produces a
  `2` over a cell the ocean also covers. Immersed geometry over water is
  physically real — breakwaters, moles, bridge piers, offshore platforms — and a
  coastal coupled domain is where ERF and REMORA are pointed. But I have not
  confirmed a real case that does it.

On that basis this is better read as **hardening a reachable-but-undemonstrated
inconsistency** than as fixing a live defect. The relaxation is defensible
independently of frequency: a cell whose surface is a building is not a sea
surface, so coupled SST does not belong there.

## Suggested follow-up, in the driver rather than here

The gap is testable, just not from this repository. `remora-erf-driver` already
has a coupled CTest harness for this shape of question
(`reproducer_coupled_sst_coverage`, which drives `Exec/Upwelling/inputs_twoway`
with runtime overrides and asserts on the driver's coverage diagnostics). A
sibling test there would close it:

- **Use coastal geometry, not buildings over open water.** Immersed geometry
  straddling a shoreline, so the blanked footprint overlaps water at the coast,
  gives the same `lmask = 2`-over-water cells from a configuration someone would
  plausibly run. A block of buildings floating on open ocean would exercise the
  branch while testing a case nobody uses.
- Assert those cells are excluded from the SST remap: ERF stamps `2`, so after
  this change both sides must treat them as land.
- **Assert the counterfactual too** — that under exact `== 1` semantics they are
  *not* excluded. Without that half the test cannot tell this fix from the old
  behaviour, because on any deck with no blanked cells the two are identical.

The last point is why it belongs in the driver: the disagreement only exists
when ERF's mask and REMORA's land test look at the same cell and differ, so
constructing it needs both models running. It would also settle the open
question above — if no realistic coastal setup stamps `2` over a coupled water
cell, that is worth knowing, and the test is how you find out.

The `.gitattributes` commit is separable; its motivation (unreadable CRLF diffs
here) was already resolved upstream in `39953ed`.