### PR TITLE
check for 2d and 3d derived variables separately in plotfile var lists

### DIFF
--- a/Source/IO/REMORA_SetPlotVars.cpp
+++ b/Source/IO/REMORA_SetPlotVars.cpp
@@ -83,9 +83,9 @@ REMORA::set3DPlotVariables (const std::string& pp_plot_var_names_3d)
         tmp_plot_names.push_back("z_cc");
     }
 
-    for (int i = 0; i < derived_names.size(); ++i) {
-        if ( containerHasElement(plot_var_names_3d, derived_names[i]) ) {
-               tmp_plot_names.push_back(derived_names[i]);
+    for (int i = 0; i < derived_names_3d.size(); ++i) {
+        if ( containerHasElement(plot_var_names_3d, derived_names_3d[i]) ) {
+               tmp_plot_names.push_back(derived_names_3d[i]);
         } // if
     } // i
 
@@ -168,9 +168,9 @@ REMORA::set2DPlotVariables (const std::string& pp_plot_var_names_2d)
     if (containerHasElement(plot_var_names_2d, "svstr")) tmp_plot_names.push_back("svstr");
     if (containerHasElement(plot_var_names_2d, "bvstr")) tmp_plot_names.push_back("bvstr");
 
-    for (int i = 0; i < derived_names.size(); ++i) {
-        if ( containerHasElement(plot_var_names_2d, derived_names[i]) ) {
-               tmp_plot_names.push_back(derived_names[i]);
+    for (int i = 0; i < derived_names_2d.size(); ++i) {
+        if ( containerHasElement(plot_var_names_2d, derived_names_2d[i]) ) {
+               tmp_plot_names.push_back(derived_names_2d[i]);
         } // if
     } // i
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1686,8 +1686,10 @@ private:
     /** \brief Names of scalars for plotfile output */
     amrex::Vector<std::string> cons_names {"temp", "salt", "tracer"};
     // Note that the order of variable names here must match the order in PlotFile.cpp
-    /** \brief Names of derived fields for plotfiles */
-    const amrex::Vector<std::string> derived_names {"vorticity"};
+    /** \brief Names of derived fields for 3d plotfile fields */
+    const amrex::Vector<std::string> derived_names_3d {"vorticity"};
+    /** \brief Names of derived fields for 2d plotfile fields */
+    const amrex::Vector<std::string> derived_names_2d {};
 
     /** \brief Container for algorithmic choices */
     static SolverChoice solverChoice;


### PR DESCRIPTION
Fixes #582 

Vorticity being added to the 2D plotfile list generates a warning, as expected.