### PR TITLE
Avoid null MultiFab references in set_surface_state

### DIFF
--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1202,33 +1202,6 @@ REMORA::set_surface_state (int lev)
             amrex::Abort("Reached set_surface_state() but variables have already been specified from driver!");
         }
     }
-//    const bool driver_has_uwind = driver_atmos_state_from_driver[AtmosState::Uwind];
-//    const bool driver_has_vwind = driver_atmos_state_from_driver[AtmosState::Vwind];
-//
-//    const bool use_analytic_uwind = bulk_flux_type[BulkFlux::Uwind] == BulkForcingType::analytic &&
-//                                    !driver_has_uwind;
-//    const bool use_analytic_vwind = bulk_flux_type[BulkFlux::Vwind] == BulkForcingType::analytic &&
-//                                    !driver_has_vwind;
-//
-//    if (use_analytic_uwind || use_analytic_vwind) {
-//        std::unique_ptr<MultiFab> tmp_uwind;
-//        std::unique_ptr<MultiFab> tmp_vwind;
-//        MultiFab* analytic_uwind = vec_uwind[lev].get();
-//        MultiFab* analytic_vwind = vec_vwind[lev].get();
-//
-//        if (!use_analytic_uwind) {
-//            tmp_uwind.reset(new MultiFab(vec_uwind[lev]->boxArray(), vec_uwind[lev]->DistributionMap(),
-//                                         1, vec_uwind[lev]->nGrowVect()));
-//            analytic_uwind = tmp_uwind.get();
-//        }
-//        if (!use_analytic_vwind) {
-//            tmp_vwind.reset(new MultiFab(vec_vwind[lev]->boxArray(), vec_vwind[lev]->DistributionMap(),
-//                                         1, vec_vwind[lev]->nGrowVect()));
-//            analytic_vwind = tmp_vwind.get();
-//        }
-//
-//        prob->init_analytic_wind(lev, geom[lev], solverChoice, *this, *analytic_uwind, *analytic_vwind);
-//    }
 
 #ifdef REMORA_USE_NETCDF
     auto update_from_netcdf = [&](std::unique_ptr<NCTimeSeries>& data_from_file,
@@ -1304,11 +1277,32 @@ REMORA::set_surface_state (int lev)
         analytic_Tair != nullptr || analytic_qair != nullptr || analytic_Pair != nullptr ||
         analytic_srflx != nullptr || analytic_lwrad != nullptr || analytic_rain != nullptr ||
         analytic_cloud != nullptr || analytic_EminusP != nullptr) {
+        // Every field has to be passed to init_analytic_surface_var, but only the
+        // analytic ones may be modified: the others hold constant or NetCDF data that is
+        // set once at level creation or interpolated just above. Hand the non-analytic
+        // slots scratch data that is thrown away on return, so the problem code can write
+        // to all ten references unconditionally without clobbering anything.
+        Vector<std::unique_ptr<MultiFab>> scratch_mf;
+        auto analytic_or_scratch = [&] (MultiFab* mf_analytic,
+                                        const std::unique_ptr<MultiFab>& mf_lev) -> MultiFab&
+        {
+            if (mf_analytic != nullptr) { return *mf_analytic; }
+            scratch_mf.emplace_back(new MultiFab(mf_lev->boxArray(), mf_lev->DistributionMap(),
+                                                 mf_lev->nComp(), mf_lev->nGrowVect()));
+            return *scratch_mf.back();
+        };
+
         prob->init_analytic_surface_var(lev, geom[lev], solverChoice, *this,
-                                        *analytic_uwind, *analytic_vwind,
-                                        *analytic_Tair, *analytic_qair, *analytic_Pair,
-                                        *analytic_srflx, *analytic_lwrad, *analytic_rain,
-                                        *analytic_cloud, *analytic_EminusP);
+                                        analytic_or_scratch(analytic_uwind, vec_uwind[lev]),
+                                        analytic_or_scratch(analytic_vwind, vec_vwind[lev]),
+                                        analytic_or_scratch(analytic_Tair, vec_Tair[lev]),
+                                        analytic_or_scratch(analytic_qair, vec_qair[lev]),
+                                        analytic_or_scratch(analytic_Pair, vec_Pair[lev]),
+                                        analytic_or_scratch(analytic_srflx, vec_srflx[lev]),
+                                        analytic_or_scratch(analytic_lwrad, vec_longwave_down[lev]),
+                                        analytic_or_scratch(analytic_rain, vec_rain[lev]),
+                                        analytic_or_scratch(analytic_cloud, vec_cloud[lev]),
+                                        analytic_or_scratch(analytic_EminusP, vec_EminusP[lev]));
     }
 
     if (vec_uwind[lev] != nullptr) { vec_uwind[lev]->FillBoundary(geom[lev].periodicity()); }


### PR DESCRIPTION
# Avoid null MultiFab references in set_surface_state

Fixes #611.

## Summary

`REMORA::set_surface_state()` bound references to null `MultiFab` pointers for
every bulk-flux surface field that is not forced analytically. Give those slots
scratch `MultiFab`s instead, so all ten references passed to
`Problem::init_analytic_surface_var` are valid and the non-analytic fields keep
their constant or NetCDF data.

## Problem

`set_surface_state()` builds a pointer per surface field:

```cpp
MultiFab* analytic_uwind = (bulk_flux_type[BulkFlux::Uwind] == BulkForcingType::analytic &&
                           !driver_atmos_state_from_driver[AtmosState::Uwind]) ? vec_uwind[lev].get() : nullptr;
```

so any field whose `*_type` is `constant` or `netcdf` yields `nullptr`. The call
is then guarded by an OR over all ten pointers, but dereferences all ten:

```cpp
if (analytic_uwind != nullptr || analytic_vwind != nullptr || ... ) {
    prob->init_analytic_surface_var(lev, geom[lev], solverChoice, *this,
                                    *analytic_uwind, *analytic_vwind, ...);
}
```

If even one field is analytic, every other field is dereferenced through a null
pointer. Binding a reference to `*(MultiFab*)nullptr` is undefined behavior on
its own — the default `BoundaryLayer` configuration does it for eight of the ten
fields, which UBSan flags — and it becomes a segfault as soon as the problem code
writes to one of those references.

`remora.uwind_type` defaults to `analytic` and nothing forces the two wind
selectors to agree, so `Exec/BoundaryLayer/inputs` plus
`remora.uwind_type=constant` is enough to reach it: `analytic_uwind` is null,
`analytic_vwind` is not, and `Source/Prob/REMORA_InitAnalyticSurfaceVar_BoundaryLayer.H`
runs `mf_Uwind.setVal(zero)` on a reference bound to null.

Analytic winds with constant or file-based humidity is a normal ROMS
configuration — there each field has its own `ana_*` routine under its own
`ANA_` macro — so mixed forcing types need to work rather than be rejected.

## Changes

`Source/REMORA.cpp`:

- Add an `analytic_or_scratch` helper that returns the real `MultiFab` for a
  field that is forced analytically, and otherwise a scratch `MultiFab` built
  from that field's `vec_*[lev]` BoxArray, DistributionMap, component count, and
  ghost cells. The scratch fabs live in a local `Vector<std::unique_ptr<MultiFab>>`
  and are discarded when the call returns.
- Pass all ten arguments through that helper.
- Delete the superseded wind-only version of the same scheme, which had been left
  commented out just above.

Writes into scratch are thrown away, so the constant values set once in
`Source/Initialization/REMORA_make_new_level.cpp:710` and the NetCDF data
interpolated a few lines above are preserved rather than overwritten by the
analytic routine — passing `vec_*[lev].get()` for every slot would have silently
clobbered them. All ten `vec_*` are allocated together under
`solverChoice.bulk_fluxes`, which is also the only path that calls
`set_surface_state()`, so the scratch fabs always have a valid template to copy
their layout from.

This keeps the `init_analytic_surface_var` signature unchanged. The alternative —
changing the virtual to take `MultiFab*` and null-checking in problem code —
avoids the per-step scratch allocation but breaks the user-facing prob API in
`Exec/REMORA_Prob.H` and makes a missing null check easy to introduce. The
scratch fabs are 2D and only allocated for non-analytic slots; if the allocation
ever matters they can be hoisted into persistent members.

## Verification

Built with the default CMake configuration (`Release`, MPI on, tests on).

Reproducer from the issue, run in both directions:

```sh
remora_exec Exec/BoundaryLayer/inputs remora.max_step=2 remora.plot_int=-1 \
    remora.uwind_type=constant remora.uwind=5.0
```

- Before the change: `Segfault` during coarse step 1, exit code 11.
- After the change: completes both steps, exit code 0.

Confirmed the constant value survives instead of being zeroed by the analytic
routine, by running the same case with `remora.uwind=5.0` and `remora.uwind=0.0`
and comparing plotfiles at step 2:

```
 variable name            absolute error            relative error
 temp                   0.0002414296086           1.027372568e-05
 salt                   0.0006387085769           2.011677606e-05
 x_velocity                0.0307396776              0.8465223967
 y_velocity               0.01972592866              0.3075077053
 z_velocity                           0                         0
```

If the scratch writes were leaking into `vec_uwind`, both runs would be
identical.

Full regression suite passes, including `BoundaryLayer`, which exercises the
default all-analytic-wind path:

```sh
ctest --test-dir Build -j 4
# 100% tests passed, 0 tests failed out of 27
```