### PR TITLE
Land per-variable BCs on the right faces, and read inflow values for every tracer

### DIFF
--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -240,13 +240,14 @@ As an example,
     remora.bc.xlo.velocity            =   1. 0.9  0.
     remora.bc.xlo.temp                =   15.
     remora.bc.xlo.salt                =   35.
-    remora.bc.xlo.value               =   2.
+    remora.bc.xlo.tracer              =   2.
 
 sets the boundary condition type at the low x face to be an inflow with xlo.type = “Inflow”.
 The velocity components take their value from ``velocity``; each tracer takes one keyed by its
-own name, with ``value`` the shared keyword for the tracers past salt. A tracer named outright
-takes precedence. ``ubar``, ``vbar``, ``zeta`` and ``tke`` have no input of their own and are
-given zero.
+own name. There is no keyword standing in for "the remaining tracers": a side covers all of
+them, so every tracer the run carries -- ``temp``, ``salt``, each dye, each biology tracer --
+needs its own entry on an inflow face, and a value always says which tracer it is for.
+``ubar``, ``vbar``, ``zeta`` and ``tke`` have no input of their own and are given zero.
 
 Because ``ubar`` and ``vbar`` are among those, an inflow face carries no barotropic normal
 velocity, and the barotropic correction holds the net volume flux through the face near zero
@@ -254,13 +255,16 @@ whatever ``velocity`` says. Tracers still enter such a face by horizontal diffus
 inflow values above are what they diffuse from, but ``inflow`` cannot presently be used to drive
 a prescribed advective transport through the boundary.
 
-In per-variable mode the prefix already names the variable, so the keyword sits under it --
+In per-variable mode the prefix already names the variable, so ``value`` sits under it --
 ``remora.bc.temp.value``, ``remora.bc.NO3.value``, ``remora.bc.u.velocity`` -- and applies to
-whichever of that variable's sides are inflow.
+whichever of that variable's sides are inflow. A tracer that takes its condition from the shared
+``remora.bc.scalar.type`` reads ``remora.bc.scalar.value`` along with it; give a tracer its own
+``.type`` to give it its own value.
 
-``value`` is the only spelling for a tracer inflow value; there is no ``scalar`` keyword for it.
-Earlier versions read ``scalar`` under a side prefix for the tracers past salt, and never read
-anything at all for temperature or salinity, so no configuration that ran correctly used it.
+``value`` is read only under a variable prefix, and there is no ``scalar`` keyword for a tracer
+inflow value at all. Earlier versions read ``scalar`` under a side prefix for the tracers past
+salt, and read nothing for temperature or salinity, so no configuration that ran correctly
+used it.
 
 An inflow face missing a tracer value stops the run at setup, naming the input it wants, as a
 missing ``velocity`` always has. There is no default: what a missing entry used to leave behind

--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -78,7 +78,10 @@ If true, conditions must be set for all of the following variables.
 - sea surface height: ``remora.bc.zeta.type``
 - turbulent kinetic energy: ``remora.bc.tke.type``
 
-They must be set to a list of four conditions in the order West, South, East, North. The options are
+They must be set to a list of four conditions in the ROMS order West, South, East, North,
+mapping onto low-\ :math:`x`, low-\ :math:`y`, high-\ :math:`x`, high-\ :math:`y`. South is the
+low-\ :math:`y` face, the one ``remora.bc.ylo.type`` names and ``*_south`` boundary data fills.
+The options are
 
 - periodic
 - inflow
@@ -235,12 +238,33 @@ As an example,
 
     remora.bc.xlo.type                =   "Inflow"
     remora.bc.xlo.velocity            =   1. 0.9  0.
-    remora.bc.xlo.scalar              =   2.
+    remora.bc.xlo.temp                =   15.
+    remora.bc.xlo.salt                =   35.
+    remora.bc.xlo.value               =   2.
 
 sets the boundary condition type at the low x face to be an inflow with xlo.type = “Inflow”.
-``scalar`` sets the inflow value for the tracers beyond temperature and salinity; in
-per-variable mode it can be given per tracer, as ``remora.bc.NO3.scalar``. Inflow values for
-temperature and salinity are not currently settable from the inputs file.
+The velocity components take their value from ``velocity``; each tracer takes one keyed by its
+own name, with ``value`` the shared keyword for the tracers past salt. A tracer named outright
+takes precedence. ``ubar``, ``vbar``, ``zeta`` and ``tke`` have no input of their own and are
+given zero.
+
+Because ``ubar`` and ``vbar`` are among those, an inflow face carries no barotropic normal
+velocity, and the barotropic correction holds the net volume flux through the face near zero
+whatever ``velocity`` says. Tracers still enter such a face by horizontal diffusion, and the
+inflow values above are what they diffuse from, but ``inflow`` cannot presently be used to drive
+a prescribed advective transport through the boundary.
+
+In per-variable mode the prefix already names the variable, so the keyword sits under it --
+``remora.bc.temp.value``, ``remora.bc.NO3.value``, ``remora.bc.u.velocity`` -- and applies to
+whichever of that variable's sides are inflow.
+
+``value`` is the only spelling for a tracer inflow value; there is no ``scalar`` keyword for it.
+Earlier versions read ``scalar`` under a side prefix for the tracers past salt, and never read
+anything at all for temperature or salinity, so no configuration that ran correctly used it.
+
+An inflow face missing a tracer value stops the run at setup, naming the input it wants, as a
+missing ``velocity`` always has. There is no default: what a missing entry used to leave behind
+was a placeholder of order :math:`10^{19}`, which ``ext_dir`` then wrote into the ghost cells.
 
 We note that ``noslipwall`` allows for non-zero tangential velocities to be specified, such as
 

--- a/Docs/sphinx_doc/RegressionTests.rst
+++ b/Docs/sphinx_doc/RegressionTests.rst
@@ -206,6 +206,52 @@ constant is unchanged by averaging, so the expected level-0 values are known out
 snapshotted. Asserting the dye is zero alongside them is what catches a regression in the
 ``Bio_comp = Tracer_comp + remora.nscalar`` offset, which would shift a biology tracer into the dye slot.
 
+.. _sec:ci-bc-tests:
+
+Boundary condition tests
+------------------------
+
+These cover the two ways of specifying boundary conditions, per side and per variable (see
+:ref:`Physical/Domain Boundary Conditions<sec:domainBCs>`). Both reach the same per-face state, so the
+assertion is that they agree and neither needs a stored reference.
+
++---------------------------------+----------+---------------------------------------------------------+
+| Test                            | nx ny nz | What it asserts                                         |
++=================================+==========+=========================================================+
+| BC_per_variable                 | 54 108 4 | a per-variable ``West South East North`` list lands on  |
+|                                 |          |                                                         |
+|                                 |          | the same four faces the per-side keywords name, and     |
+|                                 |          |                                                         |
+|                                 |          | both routes read the same inflow values                 |
++---------------------------------+----------+---------------------------------------------------------+
+| BC_inflow_no_value              | 54 108 4 | an inflow face with no inflow value for one of its      |
+|                                 |          |                                                         |
+|                                 |          | tracers is rejected, naming the input it wants          |
++---------------------------------+----------+---------------------------------------------------------+
+
+``BC_per_variable`` runs both inputs in its test directory and compares the two plotfiles. All four sides
+carry a different condition -- inflow, noslipwall, outflow, slipwall going West, South, East, North -- so
+any other order changes the answer. A y-symmetric case cannot do this, which is why the existing lanes,
+all y-symmetric, missed the South/North transposition this test was added for.
+
+The y pairing is discriminated by the *velocity* conditions specifically. For cell-centered tracers, and
+for ``zeta`` and ``tke``, ``noslipwall`` and ``slipwall`` both translate to ``foextrap``, leaving South and
+North indistinguishable in those fields; only ``u``/``v`` and ``ubar``/``vbar`` separate them, since
+``no_slip_wall`` gives ``ext_dir`` on both components while ``slip_wall`` gives ``foextrap`` tangentially
+and ``ext_dir`` normally. Substituting conditions that look equally distinct but coincide for the
+velocities would blind this lane without changing its appearance.
+
+The dye is a second readout: ``DoubleGyre`` initializes it to zero and the only dye enters through the
+western inflow value, so a nonzero tracer field means that value was read, and an agreeing one means both
+routes read it the same. Agreement alone cannot assert this -- two runs that both ignored the value would
+agree at zero -- so the lane also carries a ``check_extrema.sh`` assertion on the dye's magnitude, with a
+tolerance loose enough to be a claim about order of magnitude rather than a blessed digit string.
+
+The inflow is driven by horizontal diffusion rather than advection. ``ubar`` and ``vbar`` take no inflow
+value of their own, so the barotropic normal velocity at the face stays zero and the barotropic correction
+holds the net flux near zero regardless of the 3D ``velocity`` entry: raising it tenfold moves the dye by
+about 7%. Advective inflow is therefore not covered by either lane.
+
 Nightly Regression Tests on CPU
 -------------------------------
 And the following are currently tested nighly on CPU.

--- a/Docs/sphinx_doc/testing.rst
+++ b/Docs/sphinx_doc/testing.rst
@@ -110,6 +110,15 @@ say the baseline was right, and it cannot notice a feature that has silently sto
     needed, since ``fcompare`` aborts outright on a level-count mismatch and a bare disagreement test would
     then pass for the wrong reason.
 
+``add_test_equiv``
+    Two inputs in one test directory, describing the same configuration by different routes, must agree.
+    Neither run is a baseline, so a translation layer is covered without a gold file blessed by the code
+    under test, and neither route can drift alone. The second input needs a different plotfile prefix,
+    since both runs share a working directory. Agreement is blind to a value that both routes read wrongly
+    in the same way -- two runs that each ignore an input agree perfectly -- so trailing
+    ``<tol> <var> <min> <max> ...`` arguments add a ``check_extrema.sh`` assertion on the first run's
+    plotfile, pinning the magnitude of whatever must not go degenerate.
+
 ``add_test_extrema``
     Assert a variable's min and max against values known from outside REMORA -- a closed-form reference, or
     a constant an initial condition must reproduce. Takes any number of ``<var> <min> <max>`` triples after

--- a/Exec/Generic/inputs_generic
+++ b/Exec/Generic/inputs_generic
@@ -90,7 +90,7 @@ remora.atm2ocn_flux_mode = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.bc.bcid.type = slipwall
 
-# source: Source/Initialization/REMORA_init_bcs.cpp:252
+# source: Source/Initialization/REMORA_init_bcs.cpp:249
 # type=std::vector<std::string>; method=queryarr
 remora.bc.varname.type = outflow outflow outflow outflow
 
@@ -1785,10 +1785,6 @@ stop_time = <UNKNOWN_DEFAULT>
 # The second constructor is generally used by other classes in the code.  It permits access to the table via a large collection of query functions. Both constructors have an optional prefix argument that narrows the search to entries in the table with the same prefix.  For example, let PlanR be a
 # type=std::vector<T>; method=get
 val = <REQUIRED>
-
-# Value a tracer takes on an inflow face: keyed by the tracer's own name under a side prefix (remora.bc.xlo.temp), and by "value" under a variable prefix.
-# type=Real; method=query
-value = <UNKNOWN_DEFAULT>
 
 # Velocity components at the face, one per dimension. Required on an inflow face; optional on a no-slip wall, where leaving it out keeps the zero default. The normal component is zeroed either way, so only tangential values take effect.
 # type=std::vector<Real>; method=getarr

--- a/Exec/Generic/inputs_generic
+++ b/Exec/Generic/inputs_generic
@@ -90,7 +90,7 @@ remora.atm2ocn_flux_mode = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.bc.bcid.type = slipwall
 
-# source: Source/Initialization/REMORA_init_bcs.cpp:232
+# source: Source/Initialization/REMORA_init_bcs.cpp:252
 # type=std::vector<std::string>; method=queryarr
 remora.bc.varname.type = outflow outflow outflow outflow
 
@@ -102,19 +102,19 @@ remora.bdy_time_varname = <UNKNOWN_DEFAULT>
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_u_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1937
+# source: Source/REMORA.cpp:1931
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_ubar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1936
+# source: Source/REMORA.cpp:1930
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_v_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1938
+# source: Source/REMORA.cpp:1932
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_vbar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1939
+# source: Source/REMORA.cpp:1933
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_zeta_time_varname = <UNKNOWN_DEFAULT>
 
@@ -170,19 +170,19 @@ remora.cfl = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.change_max = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1752
+# source: Source/REMORA.cpp:1746
 # type=string; method=queryAdd
 remora.check_file = chk
 
-# source: Source/REMORA.cpp:1753
+# source: Source/REMORA.cpp:1747
 # type=int; method=queryAdd
 remora.check_int = -57600
 
-# source: Source/REMORA.cpp:1754
+# source: Source/REMORA.cpp:1748
 # type=Real; method=queryAdd
 remora.check_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1821
+# source: Source/REMORA.cpp:1815
 # type=bool; method=queryAdd
 remora.chunk_history_file = <UNKNOWN_DEFAULT>
 
@@ -222,7 +222,7 @@ remora.coriolis_type = beta_plane
 # type=string; method=queryAdd
 remora.coupling_type = TwoWay
 
-# source: Source/REMORA.cpp:1771
+# source: Source/REMORA.cpp:1765
 # type=Vector<std::string>; method=queryarr
 remora.data_log = <UNKNOWN_DEFAULT>
 
@@ -266,207 +266,207 @@ remora.eminusp_value = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.eos_type = linear
 
-# source: Source/REMORA.cpp:1755
+# source: Source/REMORA.cpp:1749
 # type=bool; method=queryAdd
 remora.expand_plotvars_to_unif_rr = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:298
+# source: Source/Biology/REMORA_Biology.cpp:297
 # type=Real; method=queryAdd
 remora.fennel.AttChl = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:297
+# source: Source/Biology/REMORA_Biology.cpp:296
 # type=Real; method=queryAdd
 remora.fennel.AttSW = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:296
+# source: Source/Biology/REMORA_Biology.cpp:295
 # type=int; method=queryAdd
 remora.fennel.BioIter = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:308
+# source: Source/Biology/REMORA_Biology.cpp:307
 # type=Real; method=queryAdd
 remora.fennel.Chl2C_m = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:309
+# source: Source/Biology/REMORA_Biology.cpp:308
 # type=Real; method=queryAdd
 remora.fennel.ChlMin = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:325
+# source: Source/Biology/REMORA_Biology.cpp:324
 # type=Real; method=queryAdd
 remora.fennel.CoagR = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:302
+# source: Source/Biology/REMORA_Biology.cpp:301
 # type=Real; method=queryAdd
 remora.fennel.D_p5NH4 = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:301
+# source: Source/Biology/REMORA_Biology.cpp:300
 # type=Real; method=queryAdd
 remora.fennel.I_thNH4 = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:305
+# source: Source/Biology/REMORA_Biology.cpp:304
 # type=Real; method=queryAdd
 remora.fennel.K_NH4 = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:304
+# source: Source/Biology/REMORA_Biology.cpp:303
 # type=Real; method=queryAdd
 remora.fennel.K_NO3 = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:306
+# source: Source/Biology/REMORA_Biology.cpp:305
 # type=Real; method=queryAdd
 remora.fennel.K_PO4 = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:307
+# source: Source/Biology/REMORA_Biology.cpp:306
 # type=Real; method=queryAdd
 remora.fennel.K_Phy = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:324
+# source: Source/Biology/REMORA_Biology.cpp:323
 # type=Real; method=queryAdd
 remora.fennel.LDeRRC = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:323
+# source: Source/Biology/REMORA_Biology.cpp:322
 # type=Real; method=queryAdd
 remora.fennel.LDeRRN = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:303
+# source: Source/Biology/REMORA_Biology.cpp:302
 # type=Real; method=queryAdd
 remora.fennel.NitriR = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:299
+# source: Source/Biology/REMORA_Biology.cpp:298
 # type=Real; method=queryAdd
 remora.fennel.PARfrac = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:310
+# source: Source/Biology/REMORA_Biology.cpp:309
 # type=Real; method=queryAdd
 remora.fennel.PhyCN = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:312
+# source: Source/Biology/REMORA_Biology.cpp:311
 # type=Real; method=queryAdd
 remora.fennel.PhyIP = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:313
+# source: Source/Biology/REMORA_Biology.cpp:312
 # type=Real; method=queryAdd
 remora.fennel.PhyIS = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:315
+# source: Source/Biology/REMORA_Biology.cpp:314
 # type=Real; method=queryAdd
 remora.fennel.PhyMR = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:314
+# source: Source/Biology/REMORA_Biology.cpp:313
 # type=Real; method=queryAdd
 remora.fennel.PhyMin = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:329
+# source: Source/Biology/REMORA_Biology.cpp:328
 # type=Real; method=queryAdd
 remora.fennel.RDeRRC = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:328
+# source: Source/Biology/REMORA_Biology.cpp:327
 # type=Real; method=queryAdd
 remora.fennel.RDeRRN = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:311
+# source: Source/Biology/REMORA_Biology.cpp:310
 # type=Real; method=queryAdd
 remora.fennel.R_P2N = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:327
+# source: Source/Biology/REMORA_Biology.cpp:326
 # type=Real; method=queryAdd
 remora.fennel.SDeRRC = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:326
+# source: Source/Biology/REMORA_Biology.cpp:325
 # type=Real; method=queryAdd
 remora.fennel.SDeRRN = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:300
+# source: Source/Biology/REMORA_Biology.cpp:299
 # type=Real; method=queryAdd
 remora.fennel.Vp0 = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:316
+# source: Source/Biology/REMORA_Biology.cpp:315
 # type=Real; method=queryAdd
 remora.fennel.ZooAE_N = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:318
+# source: Source/Biology/REMORA_Biology.cpp:317
 # type=Real; method=queryAdd
 remora.fennel.ZooBM = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:317
+# source: Source/Biology/REMORA_Biology.cpp:316
 # type=Real; method=queryAdd
 remora.fennel.ZooCN = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:319
+# source: Source/Biology/REMORA_Biology.cpp:318
 # type=Real; method=queryAdd
 remora.fennel.ZooER = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:320
+# source: Source/Biology/REMORA_Biology.cpp:319
 # type=Real; method=queryAdd
 remora.fennel.ZooGR = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:322
+# source: Source/Biology/REMORA_Biology.cpp:321
 # type=Real; method=queryAdd
 remora.fennel.ZooMR = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:321
+# source: Source/Biology/REMORA_Biology.cpp:320
 # type=Real; method=queryAdd
 remora.fennel.ZooMin = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:339
+# source: Source/Biology/REMORA_Biology.cpp:338
 # type=bool; method=queryAdd
 remora.fennel.bio_sediment = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:335
+# source: Source/Biology/REMORA_Biology.cpp:334
 # type=bool; method=queryAdd
 remora.fennel.carbon = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:366
+# source: Source/Biology/REMORA_Biology.cpp:365
 # type=string; method=queryAdd
 remora.fennel.co2_schmidt = wanninkhof1992
 
-# source: Source/Biology/REMORA_Biology.cpp:338
+# source: Source/Biology/REMORA_Biology.cpp:337
 # type=bool; method=queryAdd
 remora.fennel.denitrification = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:337
+# source: Source/Biology/REMORA_Biology.cpp:336
 # type=Array4<Real>; method=queryAdd
 remora.fennel.odu = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:336
+# source: Source/Biology/REMORA_Biology.cpp:335
 # type=bool; method=queryAdd
 remora.fennel.oxygen = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:378
+# source: Source/Biology/REMORA_Biology.cpp:377
 # type=string; method=queryAdd
 remora.fennel.oxygen_schmidt = wanninkhof1992
 
-# source: Source/Biology/REMORA_Biology.cpp:333
+# source: Source/Biology/REMORA_Biology.cpp:332
 # type=Real; method=queryAdd
 remora.fennel.pCO2air = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:352
+# source: Source/Biology/REMORA_Biology.cpp:351
 # type=string; method=queryAdd
 remora.fennel.pco2air_type = constant
 
-# source: Source/Biology/REMORA_Biology.cpp:334
+# source: Source/Biology/REMORA_Biology.cpp:333
 # type=Array4<Real>; method=queryAdd
 remora.fennel.po4 = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:340
+# source: Source/Biology/REMORA_Biology.cpp:339
 # type=bool; method=queryAdd
 remora.fennel.river_don = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:341
+# source: Source/Biology/REMORA_Biology.cpp:340
 # type=bool; method=queryAdd
 remora.fennel.talk_nonconserv = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:331
+# source: Source/Biology/REMORA_Biology.cpp:330
 # type=Real; method=queryAdd
 remora.fennel.wLDet = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:330
+# source: Source/Biology/REMORA_Biology.cpp:329
 # type=Real; method=queryAdd
 remora.fennel.wPhy = <UNKNOWN_DEFAULT>
 
-# source: Source/Biology/REMORA_Biology.cpp:332
+# source: Source/Biology/REMORA_Biology.cpp:331
 # type=Real; method=queryAdd
 remora.fennel.wSDet = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1779
+# source: Source/REMORA.cpp:1773
 # type=int; method=queryAdd
 remora.file_min_digits = 5
 
@@ -478,7 +478,7 @@ remora.fixed_dt = 300.0
 # type=Real; method=queryAdd
 remora.fixed_fast_dt = 10.0
 
-# source: Source/REMORA.cpp:1789
+# source: Source/REMORA.cpp:1783
 # type=int; method=queryAdd
 remora.fixed_ndtfast_ratio = 0
 
@@ -678,7 +678,7 @@ remora.nc_init_file_hires = <UNKNOWN_DEFAULT>
 # type=Vector<std::string>; method=queryarr
 remora.nc_river_file = "idRiv_riv_v0.2_classic64.nc"
 
-# source: Source/REMORA.cpp:1757
+# source: Source/REMORA.cpp:1751
 # type=Real; method=query
 remora.netcdf_fill_value = <UNKNOWN_DEFAULT>
 
@@ -698,31 +698,31 @@ remora.omp_tile_size = 8 8 1024000
 # type=bool; method=queryAdd
 remora.output_forcing = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1807
+# source: Source/REMORA.cpp:1801
 # type=string; method=queryAdd
 remora.plot_file = plt
 
-# source: Source/REMORA.cpp:1808
+# source: Source/REMORA.cpp:1802
 # type=int; method=queryAdd
 remora.plot_int = 100
 
-# source: Source/REMORA.cpp:1809
+# source: Source/REMORA.cpp:1803
 # type=Real; method=queryAdd
 remora.plot_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1811
+# source: Source/REMORA.cpp:1805
 # type=bool; method=query
 remora.plot_nodal_data = true
 
-# source: Source/REMORA.cpp:1810
+# source: Source/REMORA.cpp:1804
 # type=bool; method=query
 remora.plot_staggered_vels = false
 
-# source: Source/REMORA.cpp:1756
+# source: Source/REMORA.cpp:1750
 # type=Real; method=query
 remora.plotfile_fill_value = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1814
+# source: Source/REMORA.cpp:1808
 # type=string; method=queryAdd
 remora.plotfile_type = amrex
 
@@ -778,63 +778,63 @@ remora.rdrag = 0.0
 # type=Real; method=queryAdd
 remora.rdrag2 = 3.0e-3
 
-# source: Source/REMORA_Tagging.cpp:181
+# source: Source/REMORA_Tagging.cpp:200
 # type=Vector<std::string>; method=queryarr
 remora.refinement_indicators = bx1
 
-# source: Source/REMORA_Tagging.cpp:419
+# source: Source/REMORA_Tagging.cpp:438
 # type=Real; method=getarr
 remora.refinement_indicators_.adjacent_difference_greater = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:394
+# source: Source/REMORA_Tagging.cpp:413
 # type=Real; method=get
 remora.refinement_indicators_.end_time = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:406
+# source: Source/REMORA_Tagging.cpp:425
 # type=string; method=get
 remora.refinement_indicators_.field_name = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:218
+# source: Source/REMORA_Tagging.cpp:237
 # type=unknown; method=getarr
 remora.refinement_indicators_.in_box_hi = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:275
+# source: Source/REMORA_Tagging.cpp:294
 # type=unknown; method=getarr
 remora.refinement_indicators_.in_box_hi_indices = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:352
+# source: Source/REMORA_Tagging.cpp:371
 # type=unknown; method=getarr
 remora.refinement_indicators_.in_box_hi_indices_crse = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:217
+# source: Source/REMORA_Tagging.cpp:236
 # type=unknown; method=getarr
 remora.refinement_indicators_.in_box_lo = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:274
+# source: Source/REMORA_Tagging.cpp:293
 # type=unknown; method=getarr
 remora.refinement_indicators_.in_box_lo_indices = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:351
+# source: Source/REMORA_Tagging.cpp:370
 # type=unknown; method=getarr
 remora.refinement_indicators_.in_box_lo_indices_crse = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:214
+# source: Source/REMORA_Tagging.cpp:233
 # type=int; method=get
 remora.refinement_indicators_.max_level = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:390
+# source: Source/REMORA_Tagging.cpp:409
 # type=Real; method=get
 remora.refinement_indicators_.start_time = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:405
+# source: Source/REMORA_Tagging.cpp:424
 # type=Real; method=getarr
 remora.refinement_indicators_.value_greater = <REQUIRED>
 
-# source: Source/REMORA_Tagging.cpp:412
+# source: Source/REMORA_Tagging.cpp:431
 # type=Real; method=getarr
 remora.refinement_indicators_.value_less = <REQUIRED>
 
-# source: Source/REMORA.cpp:1758
+# source: Source/REMORA.cpp:1752
 # type=string; method=queryAdd
 remora.restart = <UNKNOWN_DEFAULT>
 
@@ -858,7 +858,7 @@ remora.smflux_type = analytic
 # type=Real; method=queryAdd
 remora.start_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1822
+# source: Source/REMORA.cpp:1816
 # type=int; method=queryAdd
 remora.steps_per_history_file = <UNKNOWN_DEFAULT>
 
@@ -870,7 +870,7 @@ remora.stop_time = 30000.0
 # type=int; method=queryAdd
 remora.sum_interval = -1
 
-# source: Source/REMORA.cpp:1778
+# source: Source/REMORA.cpp:1772
 # type=Real; method=queryAdd
 remora.sum_period = <UNKNOWN_DEFAULT>
 
@@ -974,7 +974,7 @@ remora.vwind = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.wind_type = analytic
 
-# source: Source/REMORA.cpp:1820
+# source: Source/REMORA.cpp:1814
 # type=bool; method=queryAdd
 remora.write_history_file = true
 
@@ -1778,10 +1778,6 @@ fab.ordering = <UNKNOWN_DEFAULT>
 # type=int; method=queryAdd
 max_step = <UNKNOWN_DEFAULT>
 
-# source: Source/Initialization/REMORA_init_bcs.cpp:88
-# type=Real; method=queryAdd
-scalar = <UNKNOWN_DEFAULT>
-
 # Traditionally, max_step and stop_time do not have prefix, so allow it for now.
 # type=Real; method=queryAdd
 stop_time = <UNKNOWN_DEFAULT>
@@ -1790,7 +1786,11 @@ stop_time = <UNKNOWN_DEFAULT>
 # type=std::vector<T>; method=get
 val = <REQUIRED>
 
-# source: Source/Initialization/REMORA_init_bcs.cpp:84
+# Value a tracer takes on an inflow face: keyed by the tracer's own name under a side prefix (remora.bc.xlo.temp), and by "value" under a variable prefix.
+# type=Real; method=query
+value = <UNKNOWN_DEFAULT>
+
+# Velocity components at the face, one per dimension. Required on an inflow face; optional on a no-slip wall, where leaving it out keeps the zero default. The normal component is zeroed either way, so only tangential values take effect.
 # type=std::vector<Real>; method=getarr
 velocity = <REQUIRED>
 

--- a/Source/Initialization/REMORA_init_bcs.cpp
+++ b/Source/Initialization/REMORA_init_bcs.cpp
@@ -89,17 +89,14 @@ void REMORA::init_bcs ()
                 pp.getarr("velocity", v, 0, AMREX_SPACEDIM);
                 m_bc_extdir_vals[bcvar_type][ori] = v[bcvar_type - xvel_bc_idx];
             } else if (uses_tracer_input(bcvar_type)) {
-                // A side covers every tracer at once, so it keys by name; a variable prefix names
-                // one already, so the bare keyword serves. Under a side prefix that keyword is
-                // the shared entry for the tracers past salt -- the fallback just below.
+                // A side covers every tracer, so each is named outright and there is no keyword
+                // standing in for "the rest": a value always says which tracer it is for. A
+                // variable prefix names one already, so the bare keyword serves there.
                 std::string const value_key = prefix_is_side ? bcvar_names[bcvar_type] : "value";
                 Real tracer_in = zero;
                 // Value a tracer takes on an inflow face: keyed by the tracer's own name under a
                 // side prefix (remora.bc.xlo.temp), and by "value" under a variable prefix.
                 bool have_value = pp.query(value_key, tracer_in);
-                if (!have_value && prefix_is_side && bcvar_type >= Tracer_comp) {
-                    have_value = pp.query("value", tracer_in);
-                }
                 // Without a value the ext_dir fill would write the placeholder below into the
                 // ghost cells. Velocity inflow already insists on one: the getarr above aborts.
                 if (!have_value) {

--- a/Source/Initialization/REMORA_init_bcs.cpp
+++ b/Source/Initialization/REMORA_init_bcs.cpp
@@ -46,12 +46,17 @@ void REMORA::init_bcs ()
         return bcvar_type == xvel_bc_idx || bcvar_type == yvel_bc_idx || bcvar_type == zvel_bc_idx;
     };
 
-    auto uses_scalar_input = [this] (int bcvar_type) noexcept {
-        return bcvar_type >= Tracer_comp && bcvar_type < ncons;
+    // Every tracer takes an inflow value; Tracer_comp starts the tracers past salt, not the tracers.
+    auto uses_tracer_input = [this] (int bcvar_type) noexcept {
+        return bcvar_type >= BCVars::cons_bc && bcvar_type < BCVars::cons_bc + ncons;
     };
 
-    auto f_set_var_bc = [this, uses_velocity_input, uses_scalar_input, xvel_bc_idx, zeta_bc_idx, ubar_bc_idx, vbar_bc_idx, bcvar_names]
-        (ParmParse& pp, int bcvar_type, Orientation ori, const std::string& bc_type_string) {
+    // prefix_is_side: pp is prefixed by a side (remora.bc.xlo), not a variable (remora.bc.temp),
+    // which decides how a value under it is keyed. Not set_bcs_by_var -- the z faces take the
+    // side form in both modes.
+    auto f_set_var_bc = [this, uses_velocity_input, uses_tracer_input, xvel_bc_idx, zeta_bc_idx, ubar_bc_idx, vbar_bc_idx, bcvar_names]
+        (ParmParse& pp, int bcvar_type, Orientation ori, const std::string& bc_type_string,
+         bool prefix_is_side) {
         // A side keyword means the same thing for every variable it covers: no tracer,
         // dye or biology, is quietly given a different condition than the one asked
         // for. A file-driven side therefore expects boundary data for each tracer the
@@ -83,11 +88,25 @@ void REMORA::init_bcs ()
                 std::vector<Real> v;
                 pp.getarr("velocity", v, 0, AMREX_SPACEDIM);
                 m_bc_extdir_vals[bcvar_type][ori] = v[bcvar_type - xvel_bc_idx];
-            } else if (uses_scalar_input(bcvar_type)) {
-                Real scalar_in = zero;
-                if (pp.queryAdd("scalar", scalar_in)) {
-                    m_bc_extdir_vals[bcvar_type][ori] = scalar_in;
+            } else if (uses_tracer_input(bcvar_type)) {
+                // A side covers every tracer at once, so it keys by name; a variable prefix names
+                // one already, so the bare keyword serves. Under a side prefix that keyword is
+                // the shared entry for the tracers past salt -- the fallback just below.
+                std::string const value_key = prefix_is_side ? bcvar_names[bcvar_type] : "value";
+                Real tracer_in = zero;
+                // Value a tracer takes on an inflow face: keyed by the tracer's own name under a
+                // side prefix (remora.bc.xlo.temp), and by "value" under a variable prefix.
+                bool have_value = pp.query(value_key, tracer_in);
+                if (!have_value && prefix_is_side && bcvar_type >= Tracer_comp) {
+                    have_value = pp.query("value", tracer_in);
                 }
+                // Without a value the ext_dir fill would write the placeholder below into the
+                // ghost cells. Velocity inflow already insists on one: the getarr above aborts.
+                if (!have_value) {
+                    amrex::Abort("Inflow boundary for " + bcvar_names[bcvar_type] +
+                                 " needs an inflow value: set " + pp.prefixedName(value_key));
+                }
+                m_bc_extdir_vals[bcvar_type][ori] = tracer_in;
             }
         }
         else if (bc_type_string == "noslipwall")
@@ -99,8 +118,9 @@ void REMORA::init_bcs ()
             if (uses_velocity_input(bcvar_type)) {
                 std::vector<Real> v;
 
-                // The values of m_bc_extdir_vals default to 0.
-                // But if we find "velocity" in the inputs file, use those values instead.
+                // Velocity components at the face, one per dimension. Required on an inflow face;
+                // optional on a no-slip wall, where leaving it out keeps the zero default. The
+                // normal component is zeroed either way, so only tangential values take effect.
                 if (pp.queryarr("velocity", v, 0, AMREX_SPACEDIM))
                 {
                     v[ori.coordDir()] = zero;
@@ -200,14 +220,14 @@ void REMORA::init_bcs ()
         std::string bc_type = amrex::toLower(bc_type_in);
 
         for (int icomp = 0; icomp < num_bc_vars(); ++icomp) {
-            f_set_var_bc(pp, icomp, ori, bc_type);
+            f_set_var_bc(pp, icomp, ori, bc_type, true);
         }
     };
 
     auto f_by_var = [this, &f_set_var_bc, zvel_bc_idx] (std::string const& varname, int bcvar_type,
                                                         std::string const& fallback_varname = "")
     {
-        amrex::Vector<Orientation> orientations = {Orientation(Direction::x,Orientation::low), Orientation(Direction::y,Orientation::high),Orientation(Direction::x,Orientation::high),Orientation(Direction::y,Orientation::low)}; // west, south, east, north [matches ROMS]
+        amrex::Vector<Orientation> orientations = {Orientation(Direction::x,Orientation::low), Orientation(Direction::y,Orientation::low),Orientation(Direction::x,Orientation::high),Orientation(Direction::y,Orientation::high)}; // west, south, east, north [matches ROMS]
         std::vector<std::string> bc_types = {"null","null","null","null"};
 
         // Additional scalars are addressable by their own name, but fall back to the
@@ -234,7 +254,7 @@ void REMORA::init_bcs ()
         for (int i=0; i<4; i++) {
             std::string bc_type = amrex::toLower(bc_types[i]);
             auto ori = orientations[i];
-            f_set_var_bc(pp, bcvar_type, ori, bc_type);
+            f_set_var_bc(pp, bcvar_type, ori, bc_type, false);
         }
     };
 
@@ -252,7 +272,8 @@ void REMORA::init_bcs ()
 
     for (OrientationIter oit; oit; ++oit) {
         Orientation ori = oit();
-        // These are simply defaults for Dirichlet faces -- they should be over-written below if needed
+        // These are simply defaults for Dirichlet faces -- they should be over-written below if needed.
+        // Tracers reach ext_dir only through inflow, which now aborts without a value.
         m_bc_extdir_vals[BCVars::Temp_bc_comp  ][ori] = Real(1.e19);
         m_bc_extdir_vals[BCVars::Salt_bc_comp  ][ori] = Real(1.e20);
         for (int icomp = Tracer_comp; icomp < ncons; ++icomp) {

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -142,6 +142,42 @@ function(add_test_r_differ TEST_NAME TEST_EXE PLTFILE OTHER_GOLD)
     )
 endfunction(add_test_r_differ)
 
+# Two inputs describing the SAME configuration by different routes must agree. Neither run is a
+# baseline, so a translation layer -- per-side against per-variable boundary specification -- is
+# covered without a gold file blessed by the code under test, and neither route can drift alone.
+# OTHER_INPUT.i sits beside TEST_NAME.i and must use a different plotfile prefix.
+#
+# Agreement alone cannot catch a value that both routes read wrongly in the SAME way: two runs
+# that each ignore an input agree perfectly. Extra arguments, "<tol> <var> <min> <max> ...", add
+# a check_extrema.sh assertion on TEST_NAME's plotfile, to pin the magnitude of something that
+# must not go degenerate. Pick <tol> loose enough to read as an order-of-magnitude claim rather
+# than a blessed digit string.
+function(add_test_equiv TEST_NAME OTHER_INPUT TEST_EXE PLTFILE OTHER_PLTFILE)
+
+    setup_test()
+
+    resolve_test_exe("${TEST_DIR}" "${TEST_EXE}" TEST_EXE)
+
+    set(FCOMPARE_TOLERANCE "-r 1e-11 --abs_tol 1.0e-11")
+    set(FCOMPARE_FLAGS "-a ${FCOMPARE_TOLERANCE}")
+    set(EXTREMA_CLAUSE "")
+    if(NOT "${ARGN}" STREQUAL "")
+        string(REPLACE ";" " " EXTREMA_ARGS "${ARGN}")
+        set(EXTREMA_CLAUSE " && ${CMAKE_CURRENT_SOURCE_DIR}/check_extrema.sh ${FEXTREMA_EXE} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE} ${EXTREMA_ARGS}")
+    endif()
+    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i > ${TEST_NAME}.log && ${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${OTHER_INPUT}.i > ${OTHER_INPUT}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${CURRENT_TEST_BINARY_DIR}/${OTHER_PLTFILE} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}${EXTREMA_CLAUSE}")
+
+    add_test(${TEST_NAME} ${test_command})
+    set_tests_properties(${TEST_NAME}
+        PROPERTIES
+        TIMEOUT 5400
+        PROCESSORS ${NP}
+        WORKING_DIRECTORY "${CURRENT_TEST_BINARY_DIR}/"
+        LABELS "regression"
+        ATTACHED_FILES_ON_FAIL "${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.log;${CURRENT_TEST_BINARY_DIR}/${OTHER_INPUT}.log"
+    )
+endfunction(add_test_equiv)
+
 # Test that a misconfigured input aborts, and aborts for the stated reason. The run must exit
 # nonzero AND the log must carry the message, so a successful run, a different abort, and a
 # segfault all fail. Deliberately not WILL_FAIL (which any nonzero exit satisfies) and not
@@ -289,6 +325,30 @@ add_test_abort(Seamount_hires_grid_max_abort  "remora_exec" "hires_grid_level mu
 add_test_abort(Seamount_hires_init_max_abort  "remora_exec" "hires_init_level must be less than or equal to amr.max_level")
 add_test_abort(Seamount_hires_grid_zero_abort "remora_exec" "hires_grid_level must be greater than 0")
 add_test_abort(Seamount_hires_flat_abort      "remora_exec" "flat_bathymetry is incompatible with hires_grid_level")
+
+#=============================================================================
+# Boundary conditions
+#
+# BC_per_variable states four conditions as one West South East North list and must land them on
+# the right faces; BC_per_side names each face outright and cannot get the order wrong.
+#
+# The y pairing is pinned by the VELOCITY conditions: for cell-centered tracers, and for zeta and
+# tke, noslipwall and slipwall both map to foextrap, so South and North are indistinguishable in
+# those fields. Only xvel/yvel and ubar/vbar tell them apart -- no_slip_wall gives ext_dir on both
+# components, slip_wall foextrap tangential and ext_dir normal. Swapping in conditions that look
+# equally distinct but agree for the velocities would silently blind this lane.
+#
+# The dye is zero in the initial condition and enters only through the western inflow value, so it
+# is nonzero only if that value was read. Agreement alone cannot assert that -- two runs that both
+# ignored the value would agree at zero -- so the extrema clause pins its magnitude. The tolerance
+# is deliberately loose: the claim is "order 0.1, and certainly not zero", not a blessed digit
+# string. Entry is by horizontal diffusion; see BC_per_variable.i on why it is not advective.
+#=============================================================================
+
+add_test_equiv(BC_per_variable BC_per_side "remora_exec" "plt00010" "plt_side00010"
+               0.05 tracer 0.0 0.127)
+
+add_test_abort(BC_inflow_no_value "remora_exec" "needs an inflow value")
 
 #=============================================================================
 # Performance tests

--- a/Tests/test_files/BC_inflow_no_value/BC_inflow_no_value.i
+++ b/Tests/test_files/BC_inflow_no_value/BC_inflow_no_value.i
@@ -1,0 +1,89 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+#
+# An inflow face with no inflow value for temperature. Nothing else supplies one, so the run
+# must stop at setup naming the missing input, rather than write the placeholder default into
+# the ghost cells. Velocity inflow has always insisted on a value the same way.
+#
+remora.prob_name = DoubleGyre
+
+remora.max_step = 10
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -500.
+remora.prob_hi     = 1000000. 2000000.       0.
+
+remora.n_cell           =  54     108      4
+
+remora.is_periodic = 0 0 0
+
+# BOUNDARY CONDITIONS
+remora.bc.xlo.type = inflow       # West
+remora.bc.ylo.type = noslipwall   # South
+remora.bc.xhi.type = outflow      # East
+remora.bc.yhi.type = slipwall     # North
+
+remora.boundary_per_variable = 0
+
+# Velocity and salt are given; temp is not, which is the point.
+remora.bc.xlo.salt     = 35.5
+remora.bc.xlo.velocity = 0. 0. 0.
+
+# TIME STEP CONTROL
+remora.fixed_dt       = 3600.0 # Timestep size (seconds)
+
+remora.fixed_ndtfast_ratio = 20
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt        # prefix of plotfile name
+remora.plot_int      = 10         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.flat_bathymetry = false
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+
+remora.Zob = 0.02
+remora.Zos = 0.02
+
+remora.rdrag = 8.0e-7
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0
+remora.Akt_bak = 1.0
+
+remora.theta_s = 0.0
+remora.theta_b = 0.0
+remora.tcline = 1e16
+
+remora.horizontal_mixing_type = constant
+remora.visc2 = 1280.0
+remora.tnu2_salt = 1280.0
+remora.tnu2_temp = 1280.0
+
+# Linear EOS parameters
+remora.R0    = 1028.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 35.0    # background salinity (nondimensional) constant
+remora.T0    = 5.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.0e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 7.3e-5
+remora.coriolis_beta = 2.0e-11

--- a/Tests/test_files/BC_per_variable/BC_per_side.i
+++ b/Tests/test_files/BC_per_variable/BC_per_side.i
@@ -32,7 +32,7 @@ remora.bc.yhi.type = slipwall     # North
 remora.boundary_per_variable = 0
 
 # Inflow values for the western face, keyed by variable name since a side covers all of them.
-# "value" is the shared keyword for the tracers past salt, here the dye alone.
+# Every tracer is named outright; there is no keyword covering "the rest".
 #
 # ylo carries the same velocity entry as xlo: per-variable mode has one entry per variable serving
 # every Dirichlet face of it, so the southern noslipwall face there sees this value too. Stating
@@ -40,7 +40,7 @@ remora.boundary_per_variable = 0
 # nonzero, so agreement means more than "both defaulted to zero".
 remora.bc.xlo.temp     = 8.0
 remora.bc.xlo.salt     = 35.5
-remora.bc.xlo.value    = 1.0
+remora.bc.xlo.tracer   = 1.0
 remora.bc.xlo.velocity = 0.1 0. 0.
 remora.bc.ylo.velocity = 0.1 0. 0.
 

--- a/Tests/test_files/BC_per_variable/BC_per_side.i
+++ b/Tests/test_files/BC_per_variable/BC_per_side.i
@@ -1,0 +1,104 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+#
+# Per-side boundary specification: the reference lane, where each face is named outright and
+# nothing depends on list order. BC_per_variable.i sets the same four faces per variable, and
+# the two runs must agree -- see add_test_equiv in Tests/CTestList.cmake.
+#
+# The dye is zero in the initial condition and enters only through the western inflow value,
+# so a nonzero tracer field means that value was read.
+#
+remora.prob_name = DoubleGyre
+
+remora.max_step = 10
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -500.
+remora.prob_hi     = 1000000. 2000000.       0.
+
+remora.n_cell           =  54     108      4
+
+remora.is_periodic = 0 0 0
+
+remora.nscalar = 1
+
+# BOUNDARY CONDITIONS
+remora.bc.xlo.type = inflow       # West
+remora.bc.ylo.type = noslipwall   # South
+remora.bc.xhi.type = outflow      # East
+remora.bc.yhi.type = slipwall     # North
+
+remora.boundary_per_variable = 0
+
+# Inflow values for the western face, keyed by variable name since a side covers all of them.
+# "value" is the shared keyword for the tracers past salt, here the dye alone.
+#
+# ylo carries the same velocity entry as xlo: per-variable mode has one entry per variable serving
+# every Dirichlet face of it, so the southern noslipwall face there sees this value too. Stating
+# it here as well keeps the two lanes equivalent while leaving the noslipwall tangential value
+# nonzero, so agreement means more than "both defaulted to zero".
+remora.bc.xlo.temp     = 8.0
+remora.bc.xlo.salt     = 35.5
+remora.bc.xlo.value    = 1.0
+remora.bc.xlo.velocity = 0.1 0. 0.
+remora.bc.ylo.velocity = 0.1 0. 0.
+
+# TIME STEP CONTROL
+remora.fixed_dt       = 3600.0 # Timestep size (seconds)
+
+remora.fixed_ndtfast_ratio = 20
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt_side   # prefix of plotfile name, kept distinct from the per-variable lane
+remora.plot_int      = 10         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp tracer x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.flat_bathymetry = false
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+
+remora.Zob = 0.02
+remora.Zos = 0.02
+
+remora.rdrag = 8.0e-7
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0
+remora.Akt_bak = 1.0
+
+remora.theta_s = 0.0
+remora.theta_b = 0.0
+remora.tcline = 1e16
+
+remora.horizontal_mixing_type = constant
+remora.visc2 = 1280.0
+remora.tnu2_salt = 1280.0
+remora.tnu2_temp = 1280.0
+remora.tnu2_scalar = 1280.0
+
+# Linear EOS parameters
+remora.R0    = 1028.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 35.0    # background salinity (nondimensional) constant
+remora.T0    = 5.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.0e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 7.3e-5
+remora.coriolis_beta = 2.0e-11

--- a/Tests/test_files/BC_per_variable/BC_per_variable.i
+++ b/Tests/test_files/BC_per_variable/BC_per_variable.i
@@ -1,0 +1,114 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+#
+# Per-variable boundary specification, pinning the West, South, East, North order: all four
+# sides carry a different condition. BC_per_side.i sets the same four faces by side, and the
+# two runs must agree -- see add_test_equiv in Tests/CTestList.cmake.
+#
+# The dye is zero in the initial condition and enters only through the western inflow value,
+# so a nonzero tracer field means that value was read.
+#
+remora.prob_name = DoubleGyre
+
+remora.max_step = 10
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -500.
+remora.prob_hi     = 1000000. 2000000.       0.
+
+remora.n_cell           =  54     108      4
+
+remora.is_periodic = 0 0 0
+
+remora.nscalar = 1
+
+# BOUNDARY CONDITIONS
+#                        West      South       East      North
+remora.bc.temp.type   =  inflow    noslipwall  outflow   slipwall
+remora.bc.salt.type   =  inflow    noslipwall  outflow   slipwall
+remora.bc.tracer.type =  inflow    noslipwall  outflow   slipwall
+remora.bc.u.type      =  inflow    noslipwall  outflow   slipwall
+remora.bc.v.type      =  inflow    noslipwall  outflow   slipwall
+remora.bc.w.type      =  inflow    noslipwall  outflow   slipwall
+remora.bc.ubar.type   =  inflow    noslipwall  outflow   slipwall
+remora.bc.vbar.type   =  inflow    noslipwall  outflow   slipwall
+remora.bc.zeta.type   =  inflow    noslipwall  outflow   slipwall
+remora.bc.tke.type    =  inflow    noslipwall  outflow   slipwall
+
+remora.boundary_per_variable = 1
+
+# One entry per variable, applying to every side of that variable that takes a Dirichlet value --
+# here the western inflow and the southern noslipwall. The velocity is nonzero so that the
+# noslipwall face is pinned to a real tangential value rather than agreeing with the other lane
+# only because both are zero; the normal component is zeroed there by init_bcs in both lanes, and
+# BC_per_side.i states the same entry on ylo so the two stay equivalent.
+#
+# The inflow is diffusive, not advective: ubar and vbar take no inflow value (uses_velocity_input
+# covers the 3D velocities alone), so the barotropic normal velocity at the face stays zero and
+# the correction holds the net flux near zero. Raising this entry tenfold moves the dye ~7%.
+remora.bc.temp.value    = 8.0
+remora.bc.salt.value    = 35.5
+remora.bc.tracer.value  = 1.0
+remora.bc.u.velocity    = 0.1 0. 0.
+remora.bc.v.velocity    = 0.1 0. 0.
+remora.bc.w.velocity    = 0.1 0. 0.
+
+# TIME STEP CONTROL
+remora.fixed_dt       = 3600.0 # Timestep size (seconds)
+
+remora.fixed_ndtfast_ratio = 20
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt        # prefix of plotfile name
+remora.plot_int      = 10         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp tracer x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.flat_bathymetry = false
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+
+remora.Zob = 0.02
+remora.Zos = 0.02
+
+remora.rdrag = 8.0e-7
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0
+remora.Akt_bak = 1.0
+
+remora.theta_s = 0.0
+remora.theta_b = 0.0
+remora.tcline = 1e16
+
+remora.horizontal_mixing_type = constant
+remora.visc2 = 1280.0
+remora.tnu2_salt = 1280.0
+remora.tnu2_temp = 1280.0
+remora.tnu2_scalar = 1280.0
+
+# Linear EOS parameters
+remora.R0    = 1028.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 35.0    # background salinity (nondimensional) constant
+remora.T0    = 5.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.0e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 7.3e-5
+remora.coriolis_beta = 2.0e-11


### PR DESCRIPTION
Fixes #608.

## Summary

Two defects in `REMORA::init_bcs`, both of which let a documented input be silently
mis-applied rather than rejected:

- A per-variable boundary list `West South East North` put South on the high-*y* face and
  North on the low-*y* one.
- An inflow face never read a temperature or salinity value, so the `ext_dir` fill wrote the
  `1.e19` / `1.e20` placeholders into the boundary ghost cells.

Both are fixed here, with a regression test that fails on either one and that no existing
lane could have caught.

## Problem

**South and North were transposed.** `f_by_var` mapped slot 1, documented as South, to
`y`-high, and slot 3, North, to `y`-low. Everywhere else south is `y`-low:
`REMORA_BoundaryConditions_netcdf.cpp` sets `apply_south` from `lo(1)`,
`REMORA_NCTimeSeriesBoundary.cpp` gates `<var>_south` on `Orientation(y,low)`, ROMS has
`isouth` at the `Jstr` edge, and PR #481 fixed exactly this transposition in the NetCDF
reader. Nothing downstream compensates — `phys_bc_type` is indexed by `Orientation` and
passed straight through — so

```
#                        West      South    East      North
remora.bc.temp.type   =  periodic  clamped  periodic  outflow
```

put the clamped condition and its NetCDF boundary data on the *northern* face, with no abort
and nothing in the output to say so. Every per-variable input in the tree gives slots 1 and 3
the same condition, so no shipped case could show it.

**Inflow values for temperature and salinity were never read.** The inflow branch tested
`bcvar_type >= Tracer_comp` — the tracers *past* salt. `Temp_bc_comp` is 0 and `Salt_bc_comp`
is 1, so temperature and salinity fell through every branch and kept the placeholders that
`REMORA_BoundaryConditions_cons.cpp` then writes into the ghost cells on an `ext_dir` face,
which for a tracer is exactly an inflow face. On the `development` tip an ordinary inflow face
dies on the second step with `Erroneous arithmetic operation` — the `1.e19` reaching the
equation of state. The same held for the tracers past salt whenever their value was omitted.

## Changes

`Source/Initialization/REMORA_init_bcs.cpp`:

- **Slot order.** `orientations` now reads `{x-lo, y-lo, x-hi, y-hi}`, matching the documented
  West, South, East, North order and the south = `y`-low convention used everywhere else.

- **Inflow values.** `uses_scalar_input` becomes `uses_tracer_input` and covers every
  cell-centered component, temperature and salinity included. A side prefix keys by the
  tracer's own name — `remora.bc.xlo.temp`, `remora.bc.xlo.NO3` — since it covers every tracer
  at once; a variable prefix keys by `value` — `remora.bc.temp.value` — since it names one
  already. There is no keyword standing in for "the remaining tracers": on an inflow face a
  value always says which tracer it is for, and every tracer the run carries needs its own.

- **No silent placeholder.** An inflow face missing a tracer value now aborts, naming the key
  that mode wants (`set remora.bc.xlo.temp`, or `set remora.bc.temp.value`). Velocity inflow
  has always insisted on a value; this is that rule applied to tracers. There is no sensible
  default: zero salinity is not more right than `1.e20`, just quieter.

  `f_set_var_bc` takes a `prefix_is_side` flag rather than reading `set_bcs_by_var` — the two
  are not the same question, since the z faces go through `f_by_side` in both modes.

Docs record the slot-to-face mapping, the inflow keys, the new test lanes, and the barotropic
limitation below. `Exec/Generic/inputs_generic` is regenerated, as `check_generic_inputs.sh`
requires whenever `Source/**` changes; the old bare `scalar` entry drops out of it, since every
key in this family is now built from a prefix and a tracer name and none is a string literal
the schema scraper can see. It had been listed as an unprefixed global named `scalar`, which
was never what the input was called.

## Backwards compatibility

**Un-flip any list that was flipped to compensate.** No answer in the tree moves — every
shipped per-variable input is y-symmetric — but a y-asymmetric user configuration changes,
which is the point.

**An inflow face now needs a value for every tracer it carries.** No input in the tree used
`inflow` before this change, so nothing in-tree moves; a user setup with an inflow face and no
tracer value now stops at setup instead of using the `1.e19`.

**`remora.bc.<side>.scalar` is gone, with no replacement keyword.** Under a side prefix each
tracer is now named outright; nothing stands in for "the rest". Under a variable prefix the
keyword is `value` rather than `scalar`, and there is no alias.

Nothing in the tree used the old spelling, and nothing outside can have used it *correctly*: a
`scalar` entry only ever applied to the tracers past salt, while temperature and salinity on
the same face were taking the `1.e19`/`1.e20` placeholders. Any configuration that set it was
already producing the garbage this PR is about, and it now stops at setup naming the tracer it
still needs a value for. `remora.bc.scalar.type`, the shared BC *type* prefix, is a different
thing and is untouched — a tracer that takes its condition from it also takes its value from
`remora.bc.scalar.value`.

## Tests

Two lanes, in a new `Boundary conditions` section of `Tests/CTestList.cmake`.

**`BC_per_variable`** runs one configuration twice, once stated per side and once per variable,
and requires the two plotfiles to agree. A new `add_test_equiv` does this: neither run is a
baseline, so a translation layer gets covered without a gold file the code under test would
have had to bless. All four sides carry a different condition — `inflow`, `noslipwall`,
`outflow`, `slipwall` — so the pairing is pinned rather than assumed.

Two things about it are worth knowing before editing it:

- *The velocity fields do the discriminating.* For cell-centered tracers, and for `zeta` and
  `tke`, `noslipwall` and `slipwall` both translate to `foextrap`, leaving South and North
  indistinguishable there; only `u`/`v` and `ubar`/`vbar` separate them. Substituting
  conditions that look equally distinct but agree for the velocities would blind the lane.
- *Agreement alone is not enough.* Two runs that both ignored an input agree perfectly, so the
  lane also asserts the dye's magnitude via `check_extrema.sh` (`0.05 tracer 0.0 0.127`) —
  loose on purpose, a claim about order of magnitude rather than a blessed digit string.
  `add_test_equiv` grows optional trailing `<tol> <var> <min> <max>` arguments for this. For
  the same reason the inflow velocity is `0.1`, not zero: with zero everywhere the two lanes
  agreed partly *because* everything was zero.

**`BC_inflow_no_value`** gives an inflow face a velocity and a salinity but no temperature and
asserts the run stops and says so. `add_test_abort` requires both the nonzero exit and the
message, so a successful run and a segfault both fail it.

## Verification

- **No existing answer changed.** No gold file was touched; 29/29 pass, the 27 pre-existing
  ones unchanged.
- **The test fails on the bug.** With only the `orientations` line reverted, the two lanes
  differ by 4% relative in `x_velocity` — nine orders of magnitude above the 1e-11 tolerance.
  With the fix, the comparison is exactly zero in every variable.
- **The reference lane is not the thing being fixed.** The per-side run is bit-identical
  before and after the change.
- **The abort fires for the stated reason in both modes,** each naming the key that mode
  actually wants.

## Notes for the reviewer

**Per-variable values are per variable, not per face.** One `velocity` and one `value` entry
per variable applies to *every* Dirichlet face of it, where per side there is one per face. So
a per-variable configuration cannot give two inflow faces different values. Worth deciding
whether the per-variable form should grow a four-entry list.

**`inflow` cannot drive advective transport.** `ubar` and `vbar` accept no inflow value, so an
inflow face carries no barotropic normal velocity and the correction holds the net flux near
zero regardless of `velocity` — raising it tenfold moves the dye maximum only from 0.127 to
0.136. Tracers enter such a face by horizontal diffusion alone, which is what the test lane
actually exercises. Same shape of gap as the tracer one fixed here, and probably wants its own
issue; documented rather than fixed.