### PR TITLE
Generalize velocity sign flip in FillBdyCCVels

### DIFF
--- a/Source/BoundaryConditions/REMORA_FillPatch.cpp
+++ b/Source/BoundaryConditions/REMORA_FillPatch.cpp
@@ -593,16 +593,39 @@ REMORA::FillCoarsePatchMap (int lev, Real time, MultiFab* mf_to_fill, MultiFab* 
 
 }
 
+namespace {
 /**
- * @param[in   ] lev    level to fill at
- * @param[in   ] lev    MultiFab of cell-centered velocities
+ * Sign for reflecting one cell-centered velocity component into a ghost cell.
+ * The normal velocity vanishes at a wall or symmetry plane; only a no-slip wall
+ * zeroes the tangential ones too. Anything else copies the adjacent valid cell.
+ *
+ * @param[in   ] bc        physical BC type for that component on that face
+ * @param[in   ] is_normal whether the component is normal to the face
+ */
+Real
+cc_vel_bdy_mult (REMORA_BC bc, bool is_normal)
+{
+    if (is_normal) {
+        return ( (bc == REMORA_BC::slip_wall   ) ||
+                 (bc == REMORA_BC::no_slip_wall) ||
+                 (bc == REMORA_BC::symmetry    ) ) ? -one : one;
+    }
+    return (bc == REMORA_BC::no_slip_wall) ? -one : one;
+}
+} // namespace
+
+/**
+ * Fill boundary ghost cells for cell-centered velocities. Each component takes
+ * the sign implied by its own BC, which with remora.boundary_per_variable can
+ * differ between u, v and w on one face.
+ *
+ * @param[in   ] lev        level to fill at
+ * @param[inout] mf_cc_vel  MultiFab of cell-centered velocities
  */
 void
 REMORA::FillBdyCCVels (int lev, MultiFab& mf_cc_vel)
 {
     // Impose bc's at domain boundaries
-//    for (int lev = 0; lev <= finest_level; ++lev)
-//    {
     Box domain(Geom(lev).Domain());
 
     int ihi = domain.bigEnd(0);
@@ -611,6 +634,19 @@ REMORA::FillBdyCCVels (int lev, MultiFab& mf_cc_vel)
 
     // Impose periodicity first
     mf_cc_vel.FillBoundary(geom[lev].periodicity());
+
+    // Sign multipliers per face, per velocity component
+    GpuArray<GpuArray<Real,AMREX_SPACEDIM>,AMREX_SPACEDIM*2> mult;
+    for (OrientationIter oit; oit; ++oit) {
+        Orientation ori = oit();
+        for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+            mult[ori][n] = cc_vel_bdy_mult(phys_bc_type[xvel_bc()+n][ori],
+                                           n == ori.coordDir());
+        }
+    }
+
+    // Callers pass different ghost widths (the plotfile ones carry none in z)
+    const IntVect ng = mf_cc_vel.nGrowVect();
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -622,72 +658,76 @@ REMORA::FillBdyCCVels (int lev, MultiFab& mf_cc_vel)
         const Box& bx = mfi.tilebox();
         const Array4<Real>& vel_arr = mf_cc_vel.array(mfi);
 
-        if (!Geom(lev).isPeriodic(0)) {
+        if (!Geom(lev).isPeriodic(0) && ng[0] > 0) {
             // Low-x side
             if (bx.smallEnd(0) <= domain.smallEnd(0)) {
-                Real mult = (phys_bc_type[xvel_bc()][0] == REMORA_BC::no_slip_wall) ? -one : one;
+                auto const m = mult[Orientation(Direction::x,Orientation::low)];
                 ParallelFor(makeSlab(bx,0,0), [=] AMREX_GPU_DEVICE(int , int j, int k) noexcept
                 {
-                    vel_arr(-1,j,k,1) = mult*vel_arr(0,j,k,1); // v
-                    vel_arr(-1,j,k,2) = mult*vel_arr(0,j,k,2); // w
+                    vel_arr(-1,j,k,0) = m[0]*vel_arr(0,j,k,0); // u
+                    vel_arr(-1,j,k,1) = m[1]*vel_arr(0,j,k,1); // v
+                    vel_arr(-1,j,k,2) = m[2]*vel_arr(0,j,k,2); // w
                 });
             }
 
             // High-x side
             if (bx.bigEnd(0) >= domain.bigEnd(0)) {
-                Real mult = (phys_bc_type[xvel_bc()][3] == REMORA_BC::no_slip_wall) ? -one : one;
+                auto const m = mult[Orientation(Direction::x,Orientation::high)];
                 ParallelFor(makeSlab(bx,0,0), [=] AMREX_GPU_DEVICE(int , int j, int k) noexcept
                 {
-                    vel_arr(ihi+1,j,k,1) = mult*vel_arr(ihi,j,k,1); // v
-                    vel_arr(ihi+1,j,k,2) = mult*vel_arr(ihi,j,k,2); // w
+                    vel_arr(ihi+1,j,k,0) = m[0]*vel_arr(ihi,j,k,0); // u
+                    vel_arr(ihi+1,j,k,1) = m[1]*vel_arr(ihi,j,k,1); // v
+                    vel_arr(ihi+1,j,k,2) = m[2]*vel_arr(ihi,j,k,2); // w
                 });
             }
         } // !periodic
 
-        if (!Geom(lev).isPeriodic(1)) {
+        if (!Geom(lev).isPeriodic(1) && ng[1] > 0) {
             // Low-y side
             if (bx.smallEnd(1) <= domain.smallEnd(1)) {
-                Real mult = (phys_bc_type[yvel_bc()][1] == REMORA_BC::no_slip_wall) ? -one : one;
+                auto const m = mult[Orientation(Direction::y,Orientation::low)];
                 ParallelFor(makeSlab(bx,1,0), [=] AMREX_GPU_DEVICE(int i, int  , int k) noexcept
                 {
-                    vel_arr(i,-1,k,0) = mult*vel_arr(i,0,k,0); // u
-                    vel_arr(i,-1,k,2) = mult*vel_arr(i,0,k,2); // w
+                    vel_arr(i,-1,k,0) = m[0]*vel_arr(i,0,k,0); // u
+                    vel_arr(i,-1,k,1) = m[1]*vel_arr(i,0,k,1); // v
+                    vel_arr(i,-1,k,2) = m[2]*vel_arr(i,0,k,2); // w
                 });
             }
 
             // High-y side
             if (bx.bigEnd(1) >= domain.bigEnd(1)) {
-                Real mult = (phys_bc_type[yvel_bc()][4] == REMORA_BC::no_slip_wall) ? -one : one;
+                auto const m = mult[Orientation(Direction::y,Orientation::high)];
                 ParallelFor(makeSlab(bx,1,0), [=] AMREX_GPU_DEVICE(int i, int , int k) noexcept
                 {
-                    vel_arr(i,jhi+1,k,0) = mult*vel_arr(i,jhi,k,0); // u
-                    vel_arr(i,jhi+1,k,2) = mult*-vel_arr(i,jhi,k,2); // w
+                    vel_arr(i,jhi+1,k,0) = m[0]*vel_arr(i,jhi,k,0); // u
+                    vel_arr(i,jhi+1,k,1) = m[1]*vel_arr(i,jhi,k,1); // v
+                    vel_arr(i,jhi+1,k,2) = m[2]*vel_arr(i,jhi,k,2); // w
                 });
             }
         } // !periodic
 
-        if (!Geom(lev).isPeriodic(2)) {
+        if (!Geom(lev).isPeriodic(2) && ng[2] > 0) {
             // Low-z side
             if (bx.smallEnd(2) <= domain.smallEnd(2)) {
-                Real mult = (phys_bc_type[zvel_bc()][2] == REMORA_BC::no_slip_wall) ? -one : one;
+                auto const m = mult[Orientation(Direction::z,Orientation::low)];
                 ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
                 {
-                    vel_arr(i,j,-1,0) = mult*vel_arr(i,j,0,0); // u
-                    vel_arr(i,j,-1,1) = mult*vel_arr(i,j,0,1); // v
+                    vel_arr(i,j,-1,0) = m[0]*vel_arr(i,j,0,0); // u
+                    vel_arr(i,j,-1,1) = m[1]*vel_arr(i,j,0,1); // v
+                    vel_arr(i,j,-1,2) = m[2]*vel_arr(i,j,0,2); // w
                 });
             }
 
             // High-z side
             if (bx.bigEnd(2) >= domain.bigEnd(2)) {
-                Real mult = (phys_bc_type[zvel_bc()][5] == REMORA_BC::no_slip_wall) ? -one : one;
+                auto const m = mult[Orientation(Direction::z,Orientation::high)];
                 ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
                 {
-                    vel_arr(i,j,khi+1,0) = mult*vel_arr(i,j,khi,0); // u
-                    vel_arr(i,j,khi+1,1) = mult*vel_arr(i,j,khi,1); // v
+                    vel_arr(i,j,khi+1,0) = m[0]*vel_arr(i,j,khi,0); // u
+                    vel_arr(i,j,khi+1,1) = m[1]*vel_arr(i,j,khi,1); // v
+                    vel_arr(i,j,khi+1,2) = m[2]*vel_arr(i,j,khi,2); // w
                 });
             }
         } // !periodic
     } // MFIter
-
-//    } // lev
 }

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -147,11 +147,15 @@ REMORA::WritePlotFile (int istep_for_plot)
 
         for (int lev = 0; lev <= finest_level; ++lev) {
             mf_cc_vel[lev].define(grids[lev], dmap[lev], AMREX_SPACEDIM, IntVect(1,1,0));
-            mf_cc_vel[lev].setVal(zero); // zero out velocity in case we have any wall boundaries
+            mf_cc_vel[lev].setVal(zero); // FillBdyCCVels below leaves corners alone
             average_face_to_cellcenter(mf_cc_vel[lev],0,
                                        Array<const MultiFab*,3>{xvel_new[lev],yvel_new[lev],zvel_new[lev]},IntVect(1,1,0));
             mf_cc_vel[lev].FillBoundary(geom[lev].periodicity());
         } // lev
+
+        // Fill level 0 before the interpolation below carries its ghost cells onto
+        // the finer levels. Matches the fill the vorticity tagging criterion uses.
+        FillBdyCCVels(0, mf_cc_vel[0]);
 
         // We need ghost cells if computing vorticity
         amrex::Interpolater* mapper = &cell_cons_interp;
@@ -167,6 +171,9 @@ REMORA::WritePlotFile (int istep_for_plot)
                                           t_new[lev], cmf, ctime, fmf, ftime,
                                           0, 0, mf_cc_vel[lev].nComp(), geom[lev-1], geom[lev],
                                           refRatio(lev-1), mapper, domain_bcs_type, foextrap_bc());
+
+                // Redo the reflections foextrap just overwrote at the domain boundary
+                FillBdyCCVels(lev, mf_cc_vel[lev]);
             } // lev
         } // if
     } // if


### PR DESCRIPTION
# Generalize the velocity sign flip in `FillBdyCCVels`

Ports the generalization ERF made in its own `FillBdyCCVels`
([f9af0f06](https://github.com/erf-model/ERF/commit/f9af0f06)). REMORA still had the older
form: a single multiplier that flipped only for `no_slip_wall`, applied to just the two
tangential components.

Also fixes #588 .

The sign now comes from a helper taking the BC type and whether the component is normal to
the face:

| BC type | normal | tangential |
| --- | --- | --- |
| `slip_wall`, `symmetry` | −1 | +1 |
| `no_slip_wall` | −1 | −1 |
| everything else | +1 | +1 |

Three consequences:

- **The normal component is now filled.** It never was. The vorticity tagging path
  allocates its MultiFab without a `setVal`, so those ghost cells held uninitialized
  memory.
- **Each component consults its own BC.** REMORA's `phys_bc_type` is indexed by variable as
  well as by face, unlike ERF's. Under `remora.boundary_per_variable`, `u`, `v` and `w` can
  differ on one face, but the old code applied the face-normal velocity's type to all three.
- **Drops a stray negation on `w` at high-y**, which left that face inconsistent with the
  other five. Same typo ERF fixed upstream.

`WritePlotFile` now calls `FillBdyCCVels` instead of relying on `setVal(zero)`, so plotted
and tagged vorticity agree at a physical boundary. Corners stay unfilled — the vorticity
stencil reads only face-adjacent ghosts.

## Note for reviewers

The plotfile's cell-centered velocities have **no ghost cell in z** (`IntVect(1,1,0)`), so
`FillBdyCCVels` writes out of bounds there unless each direction is guarded on the
available ghost width. Verified both ways: with `AMReX_ASSERTIONS` on the guarded run is
clean, and removing the z guard aborts with `malloc(): corrupted top size`.

## Testing

- Full suite 27/27, no gold files changed — expected, since no test input plots `vorticity`
  or refines on it, leaving this path previously uncovered.
- Per-side vs per-variable inputs for the same BCs are bit-identical, vorticity included,
  confirming the per-variable indexing. Deliberately y-symmetric so the
  west/south/east/north ordering can't confound it.
- `slipwall` vs `noslipwall` changes vorticity (rel. 28.6) while `z_velocity` is untouched.
- A Channel_Test case refining on `vorticity` produces a real level 1, exercising the
  tagging caller with all six faces and `fpe_trap_invalid = 1`; vorticity finite on both.

`ctest` needs `-DREMORA_ENABLE_FCOMPARE=ON` alongside `-DREMORA_ENABLE_TESTS=ON`, or
`amrex_fcompare` is never built and every comparison test fails as not-found.
