### PR TITLE
use correct cell size when calculating upwelling bathymetry

### DIFF
--- a/Source/Prob/REMORA_InitAnalyticBathymetry_Upwelling.H
+++ b/Source/Prob/REMORA_InitAnalyticBathymetry_Upwelling.H
@@ -29,7 +29,7 @@
 
               Real val1 = (iFort <= Lm/two) ? iFort : Lm+1-iFort;
               val1 -= Real(0.5);
-              Real adj = geomdata.CellSize()[1]/Real(1000.0);
+              Real adj = geomdata.CellSize()[0]/Real(1000.0);
 
               h(i,j,0) = std::min(-geomdata.ProbLo(2),(Real(84.5)+Real(66.526)*std::tanh((val1*adj-Real(10.0))/Real(7.0))));
           });
@@ -42,7 +42,7 @@
 
               Real val1 = (jFort<=Mm/two) ? jFort : Mm+1-jFort;
               val1 -= Real(0.5);
-              Real adj = geomdata.CellSize()[0]/Real(1000.0);
+              Real adj = geomdata.CellSize()[1]/Real(1000.0);
 
               h(i,j,0) = std::min(-geomdata.ProbLo(2),(Real(84.5)+Real(66.526)*std::tanh((val1*adj-Real(10.0))/Real(7.0))));
           });

--- a/Source/Prob/REMORA_InitAnalyticBathymetry_Upwelling_ML.H
+++ b/Source/Prob/REMORA_InitAnalyticBathymetry_Upwelling_ML.H
@@ -38,7 +38,7 @@
 
                     Real val1 = (jFort<=Mm/two) ? jFort : Mm+1-jFort;
                     val1 -= Real(0.5);
-                    Real adj = geomdata.CellSize()[0]/(Real(1000.0) * rrx);
+                    Real adj = geomdata.CellSize()[1]/(Real(1000.0) * rry);
 
                     h(i,j,0) = std::min(-geomdata.ProbLo(2),(Real(84.5)+Real(66.526)*std::tanh((val1*adj-Real(10.0))/Real(7.0))));
                 });
@@ -50,7 +50,7 @@
 
                     Real val1 = (iFort <= Lm/two) ? iFort : Lm+1-iFort;
                     val1 -= Real(0.5);
-                    Real adj = geomdata.CellSize()[1]/(Real(1000.0) * rry);
+                    Real adj = geomdata.CellSize()[0]/(Real(1000.0) * rrx);
 
                     h(i,j,0) = std::min(-geomdata.ProbLo(2),(Real(84.5)+Real(66.526)*std::tanh((val1*adj-Real(10.0))/Real(7.0))));
                 });
@@ -81,7 +81,7 @@
 
                     Real val1 = (jFort<=Mm/two) ? jFort : Mm+1-jFort;
                     val1 -= Real(0.5);
-                    Real adj = geomdata.CellSize()[0]/Real(1000.0);
+                    Real adj = geomdata.CellSize()[1]/Real(1000.0);
 
                     h(i,j,0) = std::min(-geomdata.ProbLo(2),(Real(84.5)+Real(66.526)*std::tanh((val1*adj-Real(10.0))/Real(7.0))));
                 });
@@ -93,7 +93,7 @@
 
                     Real val1 = (iFort <= Lm/two) ? iFort : Lm+1-iFort;
                     val1 -= Real(0.5);
-                    Real adj = geomdata.CellSize()[1]/Real(1000.0);
+                    Real adj = geomdata.CellSize()[0]/Real(1000.0);
 
                     h(i,j,0) = std::min(-geomdata.ProbLo(2),(Real(84.5)+Real(66.526)*std::tanh((val1*adj-Real(10.0))/Real(7.0))));
                 });


### PR DESCRIPTION
Was previously perpendicular cell size. Fixes #595