### PR TITLE
apply river_Vshape only to river_transport, not to tracers

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -1696,6 +1696,12 @@ dimensions ``(river_time, s_rho, river)``, following the ROMS convention:
 field is missing REMORA aborts and names it, rather than failing inside the NetCDF
 reader.
 
+Tracer fields are concentrations, so a tracer given without an ``s_rho`` dimension,
+as ``(river_time, river)``, is used unchanged at every vertical level, and REMORA
+prints a warning naming the field. ``river_Vshape`` applies only to
+``river_transport``, where it distributes the total transport over the vertical as
+ROMS does with ``Qsrc = Qbar * Qshape``; it is not applied to tracers.
+
 Runtime Error Checking
 ======================
 

--- a/Source/IO/REMORA_NCTimeSeriesRiver.H
+++ b/Source/IO/REMORA_NCTimeSeriesRiver.H
@@ -15,7 +15,8 @@ class NCTimeSeriesRiver
         NCTimeSeriesRiver (const amrex::Vector<std::string>& a_file_names,
                            const std::string a_field_name,
                            const std::string a_time_name,
-                           const int a_nz, const int a_use_vert_integ=0);
+                           const int a_nz, const int a_use_vert_integ=0,
+                           const int a_is_transport=0);
 
         void Initialize ();
 
@@ -30,12 +31,16 @@ class NCTimeSeriesRiver
         /// Whether to use the depth-integrated value read from file; Used
         /// when !has_z
         int use_vert_integ;
+        /// Whether this field is the river transport, as opposed to a tracer
+        /// concentration. Only the transport is distributed in the vertical by
+        /// river_Vshape (ROMS Qsrc = Qbar*Qshape)
+        int is_transport;
 
         /// FABs to pointers of river data
         amrex::FArrayBox* fab_before;
         amrex::FArrayBox* fab_after;
         /// Vshape data if needed
-        amrex::FArrayBox* fab_vshape;
+        amrex::FArrayBox* fab_vshape = nullptr;
 
         /**
          * Read in data from file at time index itime and fill into FAB

--- a/Source/IO/REMORA_NCTimeSeriesRiver.cpp
+++ b/Source/IO/REMORA_NCTimeSeriesRiver.cpp
@@ -13,15 +13,18 @@
  * @param[in   ] a_time_name          name of time variable in NetCDF file
  * @param[in   ] a_nz                 number of vertical levels in domain
  * @param[in   ] a_use_vert_integ     whether the data in the file is vertically integrated
+ * @param[in   ] a_is_transport       whether the field is the river transport rather than a tracer
  */
 NCTimeSeriesRiver::NCTimeSeriesRiver (const amrex::Vector<std::string>& a_file_names, const std::string a_field_name,
                                       const std::string a_time_name,
-                                      const int a_nz, const int a_use_vert_integ) {
+                                      const int a_nz, const int a_use_vert_integ,
+                                      const int a_is_transport) {
     file_names.assign(a_file_names.begin(), a_file_names.end());
     time_name = a_time_name;
     field_name = a_field_name;
     nz   = a_nz;
     use_vert_integ = a_use_vert_integ;
+    is_transport = a_is_transport;
 }
 
 void NCTimeSeriesRiver::Initialize() {
@@ -100,8 +103,18 @@ void NCTimeSeriesRiver::Initialize() {
     amrex::ParallelDescriptor::Bcast(&has_z, 1, ioproc);
     amrex::ParallelDescriptor::Bcast(&nriv, 1, ioproc);
 
+    // river_Vshape distributes the total transport in the vertical (ROMS Qsrc = Qbar*Qshape),
+    // so it applies only to the transport. A tracer given as (river_time, river) is a
+    // concentration, and is used unscaled at every level.
+    if (!has_z && !is_transport) {
+        amrex::Print() << "Warning: " << field_name << " has no s_rho dimension in "
+                       << file_names[0] << "; the same value will be used at every "
+                       << "vertical level. ROMS expects river tracers to be given as "
+                       << "(river_time, s_rho, river)." << std::endl;
+    }
+
     amrex::Box vshape_box(amrex::IntVect(0,0,0),amrex::IntVect(nriv,0,nz));
-    if (!has_z && !use_vert_integ) {
+    if (!has_z && !use_vert_integ && is_transport) {
         amrex::Vector<amrex::FArrayBox*> NC_fabs;
         amrex::Vector<std::string> NC_names;
         amrex::Vector<enum NC_Data_Dims_Type> NC_dim_types;
@@ -198,10 +211,16 @@ void NCTimeSeriesRiver::read_in_at_time (amrex::FArrayBox* fab_dat, int itime) {
         amrex::ParallelFor(fab_domain, [=] AMREX_GPU_DEVICE (int r, int , int k) {
             dat_array(r,0,k) = tmp_array(r,0,k);
         });
-    } else {
+    } else if (is_transport) {
+        // Distribute the vertically integrated transport over the levels
         auto array_vshape = fab_vshape->const_array();
         amrex::ParallelFor(fab_domain, [=] AMREX_GPU_DEVICE (int r, int , int k) {
             dat_array(r,0,k) = tmp_array(r,0,0) * array_vshape(r,0,k);
+        });
+    } else {
+        // Concentration given only as (river_time, river); use it at every level
+        amrex::ParallelFor(fab_domain, [=] AMREX_GPU_DEVICE (int r, int , int k) {
+            dat_array(r,0,k) = tmp_array(r,0,0);
         });
     }
 }

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1539,9 +1539,9 @@ REMORA::init_only (int lev, Real time)
             river_source_cons[icomp].reset(new NCTimeSeriesRiver(nc_riv_file, field, riv_time_varname, nz));
             river_source_cons[icomp]->Initialize();
         }
-        river_source_transport.reset(new NCTimeSeriesRiver(nc_riv_file, "river_transport", riv_time_varname, nz));
+        river_source_transport.reset(new NCTimeSeriesRiver(nc_riv_file, "river_transport", riv_time_varname, nz, 0, 1));
         river_source_transport->Initialize();
-        river_source_transportbar.reset(new NCTimeSeriesRiver(nc_riv_file, "river_transport", riv_time_varname, nz, 1));
+        river_source_transportbar.reset(new NCTimeSeriesRiver(nc_riv_file, "river_transport", riv_time_varname, nz, 1, 1));
         river_source_transportbar->Initialize();
         init_riv_pos_from_netcdf(lev);
     }


### PR DESCRIPTION
# Apply `river_Vshape` only to `river_transport`, not to river tracers

Fixes #594.

## The problem

`NCTimeSeriesRiver` inferred what kind of field it was carrying from the variable's
rank in the NetCDF file. Any field that came in as 2D — `(river_time, river)` — got
multiplied by `river_Vshape` in `read_in_at_time`:

```cpp
dat_array(r,0,k) = tmp_array(r,0,0) * array_vshape(r,0,k);
```

`river_Vshape` is ROMS's `Qshape`, and it belongs to the transport alone:
`set_ngfldr`/`ana_psource` build `Qsrc(is,k) = Qbar(is)*Qshape(is,k)`, while `Tsrc`
comes straight from `river_temp`/`river_salt` as a per-level concentration.

Because `Qshape` sums to 1 over `s_rho`, a tracer that arrived as 2D was stored as
`conc * Vshape`. With `Nz` levels and a uniform `Vshape` that is `conc/Nz` at every
level — the injected tracer content is short by roughly a factor of `Nz`, with a
spurious vertical profile on top. The consumers want the value unscaled:
`REMORA_advance_3d.cpp` sets `u` from `river_transport` (Vshape already applied),
and then `REMORA_prestep_t_advection.cpp` and `REMORA_rhs_t_3d.cpp` form
`FX = Huon(i,j,k) * river_source(iriver,0,k)`.

## The change

Give the class an explicit `is_transport` flag rather than guessing from rank. It
defaults to false and is set true only for the two `river_transport` objects in
`REMORA::init_only`. When it is false and the file variable is 2D, the concentration
is broadcast over `k`, and the `river_Vshape` read in `Initialize()` is skipped so a
file carrying no `Vshape` still works for tracers.

ROMS's `rivers.cdl` declares `river_temp`/`river_salt` as `(river_time, s_rho, river)`,
and `get_ngfld` would abort on the rank mismatch. This takes the permissive route and
warns instead, naming the field:

```
Warning: river_temp has no s_rho dimension in idRiv_riv_2d.nc; the same value will be
used at every vertical level. ROMS expects river tracers to be given as
(river_time, s_rho, river).
```

Aborting would be equally defensible — happy to switch if that's preferred.

## Verification

The `IdealRivGrid` river file has vertically uniform `river_temp` (20 everywhere) and
`river_salt` (0 everywhere), so a 2D-collapsed copy of it is physically identical to
the 3D original. That makes a clean A/B test:

| run | river file | result vs. 3D reference |
|---|---|---|
| pre-fix | 2D tracers | `temp` abs err `6.56e-4`, rel err `3.28e-5` |
| post-fix | 2D tracers | **exactly 0 on every variable — `PLOTFILE AGREE`** |

(`salt` shows no error either way because it is identically zero in the file, so the
erroneous `Vshape` multiply has nothing to scale.)

Full regression suite: **29/29 passing.** The existing gold files are untouched —
`IdealRivGrid` supplies 3D `river_temp`/`river_salt`, which take the same code path as
before, and `river_transport` is 2D and still gets its `Vshape` multiply.