### PR TITLE
compare clim-nudging box hi end to the nodal index, not dhi

### DIFF
--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1045,6 +1045,24 @@ public:
                    const amrex::Array4<amrex::Real const>& dmde,
                    int nrhs, int nr);
 
+    /** \brief Shrink an x- or y-nodal momentum tilebox to the faces ROMS nudges
+     *
+     * ROMS nudges momentum toward climatology over i=IstrU..Iend (j=JstrV..Jend), which
+     * excludes the u-face on the western and eastern domain edges (v-face on the southern
+     * and northern edges). This returns the part of \p nodal_bx that survives that
+     * exclusion. Under EW_PERIODIC (NS_PERIODIC) ROMS sets IstrU=Istr (JstrV=Jstr) and
+     * nudges every face, so a periodic direction is left alone.
+     *
+     * @param[in] nodal_bx    box from MFIter::nodaltilebox(dir)
+     * @param[in] dir         direction the box is nodal in (0 for u, 1 for v)
+     * @param[in] domain      cell-centered problem domain at this level
+     * @param[in] is_periodic whether \p dir is periodic
+     */
+    static amrex::Box clim_nudg_momentum_box (const amrex::Box& nodal_bx,
+                   int dir,
+                   const amrex::Box& domain,
+                   bool is_periodic);
+
     /** \brief Apply climatology nudging */
     void apply_clim_nudg (const amrex::Box& bx,
                    int ioff, int joff,

--- a/Source/TimeIntegration/REMORA_advance_2d.cpp
+++ b/Source/TimeIntegration/REMORA_advance_2d.cpp
@@ -109,9 +109,6 @@ REMORA::advance_2d (int lev,
     MultiFab mf_DUon(convert(ba,IntVect(1,0,0)),dm,1,IntVect(NGROW,NGROW,0));
     MultiFab mf_DVom(convert(ba,IntVect(0,1,0)),dm,1,IntVect(NGROW,NGROW,0));
 
-    const auto dlo = amrex::lbound(Geom(lev).Domain());
-    const auto dhi = amrex::ubound(Geom(lev).Domain());
-
     int ncomp = 0;
     int fomn_comp = ncomp++;
     int Drhs_comp = ncomp++;
@@ -244,28 +241,6 @@ REMORA::advance_2d (int lev,
 
         Box ybxD = mfi.nodaltilebox(1);
         ybxD.makeSlab(2,0);
-
-        Box xbxD_adj = mfi.nodaltilebox(0);
-        xbxD_adj.makeSlab(2,0);
-        Box ybxD_adj = mfi.nodaltilebox(1);
-        ybxD_adj.makeSlab(2,0);
-
-        auto xbxD_lo = lbound(xbxD_adj);
-        auto xbxD_hi = ubound(xbxD_adj);
-        auto ybxD_lo = lbound(ybxD_adj);
-        auto ybxD_hi = ubound(ybxD_adj);
-
-        if (xbxD_lo.x == dlo.x) {
-            xbxD_adj.growLo(0,-1);
-        } else if (xbxD_hi.x == dhi.x) {
-            xbxD_adj.growHi(0,-1);
-        }
-
-        if (ybxD_lo.y == dlo.y) {
-            ybxD_adj.growLo(1,-1);
-        } else if (ybxD_hi.y == dhi.y) {
-            ybxD_adj.growHi(1,-1);
-        }
 
         Box tbxp1  = bx;  tbxp1.grow(IntVect(NGROW-1,NGROW-1,0));
         Box tbxp2  = bx;  tbxp2.grow(IntVect(NGROW,NGROW,0));
@@ -582,7 +557,14 @@ REMORA::advance_2d (int lev,
             Array4<const Real> const& vbar_clim = vbar_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
             Array4<const Real> const& ubar_nudg_coeff = vec_nudg_coeff[bdy_ubar()][lev]->const_array(mfi);
             Array4<const Real> const& vbar_nudg_coeff = vec_nudg_coeff[bdy_vbar()][lev]->const_array(mfi);
-            // Boxes are like this to match ROMS
+            // Boxes are like this to match the ROMS loops i=IstrU..Iend, j=JstrV..Jend, which
+            // exclude the u-face on the west/east domain edges and the v-face on south/north
+            Box xbxD_adj = clim_nudg_momentum_box(mfi.nodaltilebox(0), 0,
+                                                  Geom(lev).Domain(), Geom(lev).isPeriodic(0));
+            xbxD_adj.makeSlab(2,0);
+            Box ybxD_adj = clim_nudg_momentum_box(mfi.nodaltilebox(1), 1,
+                                                  Geom(lev).Domain(), Geom(lev).isPeriodic(1));
+            ybxD_adj.makeSlab(2,0);
             apply_clim_nudg(xbxD_adj, 1, 0, rhs_ubar, ubar_krhs, ubar_clim, ubar_nudg_coeff, Drhs_const, pm, pn);
             apply_clim_nudg(ybxD_adj, 0, 1, rhs_vbar, vbar_krhs, vbar_clim, vbar_nudg_coeff, Drhs_const, pm, pn);
         }

--- a/Source/TimeIntegration/REMORA_apply_clim_nudg.cpp
+++ b/Source/TimeIntegration/REMORA_apply_clim_nudg.cpp
@@ -41,3 +41,42 @@ REMORA::apply_clim_nudg (const Box& bx,
         var(i,j,k) += cff * (var_clim(i,j,k) - var_old(i,j,k));
     });
 }
+
+/**
+ * @param[in   ] nodal_bx       box from MFIter::nodaltilebox(dir)
+ * @param[in   ] dir            direction the box is nodal in (0 for u, 1 for v)
+ * @param[in   ] domain         cell-centered problem domain at this level
+ * @param[in   ] is_periodic    whether dir is periodic
+ */
+Box
+REMORA::clim_nudg_momentum_box (const Box& nodal_bx,
+                                const int dir,
+                                const Box& domain,
+                                const bool is_periodic)
+{
+    Box bx(nodal_bx);
+
+    // ROMS sets IstrU=Istr (JstrV=Jstr) under EW_PERIODIC (NS_PERIODIC), so a periodic
+    // direction keeps every face.
+    if (is_periodic) {
+        return bx;
+    }
+
+    // MFIter::nodaltilebox calls surroundingNodes(dir) and only strips the high node when the
+    // tile stops short of the valid high end, so a box on the domain high edge legitimately
+    // ends at domain.bigEnd(dir)+1 -- the same convention as bx_xhi_face.setSmall(0,dom_hi.x+1)
+    // in the boundary conditions. Comparing against the cell-centered domain.bigEnd(dir) would
+    // never match there, and would wrongly match a box whose last cell is domain hi minus one.
+    const int nodal_lo = domain.smallEnd(dir);
+    const int nodal_hi = domain.bigEnd(dir) + 1;
+
+    // Independent tests, not else-if: a box spanning the domain in dir sheds both edge faces.
+    if (bx.smallEnd(dir) == nodal_lo) {
+        bx.growLo(dir,-1);
+    }
+    if (bx.bigEnd(dir) == nodal_hi) {
+        bx.growHi(dir,-1);
+    }
+
+    return bx;
+}

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -120,9 +120,6 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
 
     auto N = Geom(lev).Domain().size()[2]-1; // Number of vertical "levs" aka, NZ
 
-    const auto dlo = amrex::lbound(Geom(lev).Domain());
-    const auto dhi = amrex::ubound(Geom(lev).Domain());
-
     for ( MFIter mfi(S_new, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real const> const& h     = vec_h[lev]->const_array(mfi);
@@ -384,25 +381,6 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
         Box tbxp2 = bx;
         Box xbx = mfi.nodaltilebox(0);
         Box ybx = mfi.nodaltilebox(1);
-        Box xbx_adj = mfi.nodaltilebox(0);
-        Box ybx_adj = mfi.nodaltilebox(1);
-
-        auto xbx_lo = lbound(xbx_adj);
-        auto xbx_hi = ubound(xbx_adj);
-        auto ybx_lo = lbound(ybx_adj);
-        auto ybx_hi = ubound(ybx_adj);
-
-        if (xbx_lo.x == dlo.x) {
-            xbx_adj.growLo(0,-1);
-        } else if (xbx_hi.x == dhi.x) {
-            xbx_adj.growHi(0,-1);
-        }
-
-        if (ybx_lo.y == dlo.y) {
-            ybx_adj.growLo(1,-1);
-        } else if (ybx_hi.y == dhi.y) {
-            ybx_adj.growHi(1,-1);
-        }
 
         Box gbx1 = mfi.growntilebox(IntVect(NGROW-1,NGROW-1,0));
         Box gbx2 = mfi.growntilebox(IntVect(NGROW,NGROW,0));
@@ -480,7 +458,12 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
             Array4<const Real> const& vclim = v_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
             Array4<const Real> const& u_nudg_coeff = vec_nudg_coeff[BdyVars::u][lev]->const_array(mfi);
             Array4<const Real> const& v_nudg_coeff = vec_nudg_coeff[BdyVars::v][lev]->const_array(mfi);
-            // These boxes are set to match ROMS
+            // These boxes are set to match the ROMS loops i=IstrU..Iend, j=JstrV..Jend, which
+            // exclude the u-face on the west/east domain edges and the v-face on south/north
+            const Box xbx_adj = clim_nudg_momentum_box(mfi.nodaltilebox(0), 0,
+                                                       Geom(lev).Domain(), Geom(lev).isPeriodic(0));
+            const Box ybx_adj = clim_nudg_momentum_box(mfi.nodaltilebox(1), 1,
+                                                       Geom(lev).Domain(), Geom(lev).isPeriodic(1));
             apply_clim_nudg(xbx_adj, 1, 0, ru, uold, uclim, u_nudg_coeff, Hz, pm, pn);
             apply_clim_nudg(ybx_adj, 0, 1, rv, vold, vclim, v_nudg_coeff, Hz, pm, pn);
         }


### PR DESCRIPTION
The momentum climatology-nudging boxes in setup_step (3D ru/rv) and advance_2d (2D rhs_ubar/rhs_vbar) tried to reproduce the ROMS nudging loops i=IstrU..Iend, j=JstrV..Jend, which exclude the u-face on the west and east domain edges and the v-face on the south and north edges. Two things kept them from doing that:

  - The high-side test compared the ubound of an x/y-nodal box against the cell-centered domain hi. MFIter::nodaltilebox calls surroundingNodes and only strips the high node when the tile stops short of the valid high end, so a box on the domain high edge ends at dhi+1 and `xbx_hi.x == dhi.x` never matched there. The eastern and northern edge faces were nudged while the western and southern ones were excluded. The test did match a grid whose last cell is dhi.x-1, wrongly dropping an interior face and making the result depend on the grid decomposition.

  - The lo and hi adjustments were chained with `else if`, so a box spanning the domain in a direction -- the single-grid case -- could only ever shed its low face.

Fold the adjustment into one REMORA::clim_nudg_momentum_box helper, since the block was byte-identical in the two files, and have it compare the high side against domain.bigEnd(dir)+1 with independent lo/hi tests. In a periodic direction it returns the box untouched: ROMS sets IstrU=Istr under EW_PERIODIC and nudges every face, and the previous code wrongly dropped the west/south face there. The boxes are now built inside the existing REMORA_USE_NETCDF / do_m*_clim_nudg blocks, which are their only consumer.

Verified against amrex::MFIter directly: for the IdealMiniGrid clim-nudging domain (10x16x20) the old boxes covered u-faces 1..10 and v-faces 1..16; they now cover 1..9 and 1..15, matching ROMS. The Exec/IdealMiniGrid inputs_clim_nudg case is bit-identical over 10 steps before and after, because its all-boundary orlanski_rad/Flather conditions overwrite the edge faces before the tendency reaches the state -- so no clim-nudging baseline moves here, contrary to what the issue anticipated. All 29 registered ctests pass.

Fixes #601