### PR TITLE
sync stream before host touches pinned boundary fabs

### DIFF
--- a/Source/IO/REMORA_NCTimeSeriesBoundary.cpp
+++ b/Source/IO/REMORA_NCTimeSeriesBoundary.cpp
@@ -280,6 +280,10 @@ void NCTimeSeriesBoundary::update_interpolated_to_time (amrex::Real time)
             interp_fab(crse_ylo_dat, ylo_dat_after);
             interp_fab(crse_yhi_dat, yhi_dat_after);
 
+            // The_Pinned_Arena is not stream-ordered, so wait for interp_fab's
+            // kernels before these fabs are freed at return
+            amrex::Gpu::streamSynchronize();
+
         }
 
     } else if (i_time_before_old != i_time_before) {
@@ -309,6 +313,10 @@ void NCTimeSeriesBoundary::update_interpolated_to_time (amrex::Real time)
             interp_fab(crse_xhi_dat, xhi_dat_after);
             interp_fab(crse_ylo_dat, ylo_dat_after);
             interp_fab(crse_yhi_dat, yhi_dat_after);
+
+            // The_Pinned_Arena is not stream-ordered, so wait for interp_fab's
+            // kernels before these fabs are freed at return
+            amrex::Gpu::streamSynchronize();
         } // lev
     } // i_time
 
@@ -371,6 +379,10 @@ void NCTimeSeriesBoundary::read_in_at_time (amrex::FArrayBox& fab_xlo,
                                             amrex::FArrayBox& fab_ylo,
                                             amrex::FArrayBox& fab_yhi,
                                             int itime) {
+    // The host writes below land in pinned fabs that queued kernels may still be
+    // reading in place, so drain the stream first
+    amrex::Gpu::streamSynchronize();
+
     using RARRAY = NDArray<amrex::Real>;
     amrex::Vector<RARRAY> arrays(nc_var_names.size());
 


### PR DESCRIPTION
Fixes #592 

NCTimeSeriesBoundary holds its boundary fabs in The_Pinned_Arena on GPU builds, so interp_fab's ParallelFor reads them in place and returns before the kernel has run. read_in_at_time then host-overwrote those fabs with the interp kernels still queued, and the pinned arena is not stream- ordered, so the crse_* locals could also be freed mid-kernel.

Sync at the top of read_in_at_time and at the end of each lev>0 branch. No-op on CPU builds.