### PR TITLE
fix particle init OpenMP race and duplicated corner in cell-center z

### DIFF
--- a/Source/Particles/REMORA_PC_Init.cpp
+++ b/Source/Particles/REMORA_PC_Init.cpp
@@ -95,7 +95,7 @@ void REMORAPC::initializeParticlesUniformDistributionInBox (const std::unique_pt
                 Real z = Real(0.125) * (height_arr(i,j  ,k  ) + height_arr(i+1,j  ,k  ) +
                                   height_arr(i,j+1,k  ) + height_arr(i+1,j+1,k  ) +
                                   height_arr(i,j  ,k+1) + height_arr(i+1,j  ,k+1) +
-                                  height_arr(i,j+1,k+1) + height_arr(i+1,j+1,k  ) );
+                                  height_arr(i,j+1,k+1) + height_arr(i+1,j+1,k+1) );
                 if (particle_init_domain.contains(RealVect(x,y,z))) {
                     num_particles_arr(i,j,k) = particles_per_cell;
                 }
@@ -119,6 +119,12 @@ void REMORAPC::initializeParticlesUniformDistributionInBox (const std::unique_pt
                        1, 0 );
     offsets.setVal(0);
 
+    // Define the tiles in serial; the map of tiles is not safe to grow
+    // concurrently in the OpenMP region below. Same as AMReX's addParticles.
+    for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi) {
+        DefineAndReturnParticleTile(lev, mfi);
+    }
+
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -138,7 +144,8 @@ void REMORAPC::initializeParticlesUniformDistributionInBox (const std::unique_pt
         }
         auto offset_arr = offsets[mfi].array();
 
-        auto& particle_tile = DefineAndReturnParticleTile(lev, mfi);
+        // already defined in the serial pass above
+        auto& particle_tile = ParticlesAt(lev, mfi);
         particle_tile.resize(np);
         auto aos = &particle_tile.GetArrayOfStructs()[0];
         auto& soa = particle_tile.GetStructOfArrays();
@@ -151,6 +158,9 @@ void REMORAPC::initializeParticlesUniformDistributionInBox (const std::unique_pt
 
         auto my_proc = ParallelDescriptor::MyProc();
         Long pid;
+#ifdef _OPENMP
+#pragma omp critical (remora_particle_nextid)
+#endif
         {
             pid = ParticleType::NextID();
             ParticleType::NextID(pid+np);


### PR DESCRIPTION
The second MFIter loop in initializeParticlesUniformDistributionInBox runs under omp parallel, but DefineAndReturnParticleTile grows m_particles[lev], a std::map, and the NextID()/NextID(pid+np) pair is not atomic (the getter is, the setter is not). Concurrent map growth aborts with map::at out_of_range on 4+ threads, and the overlapping reservations give duplicate (id,cpu). Define the tiles in a serial pre-pass as AMReX's addParticles does, look them up with ParticlesAt inside the region, and serialize the reserve with omp critical.

Separately, the 8-corner nodal-to-cell-center average of z_phys_nd repeated height_arr(i+1,j+1,k) and omitted height_arr(i+1,j+1,k+1), biasing the z used to test particle_init_domain.contains() low by Hz/8. Restore the eighth corner, matching z_cc in REMORA_Plotfile.cpp.

Fixes #593.