### PR TITLE
Fix NetCDF plotfile GPU sync and ocean_time length (#606)

### DIFF
--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -141,6 +141,13 @@ Notes
 
 -  The write_history_file option is only available if **plotfile_type = netcdf**
 
+-  A NetCDF history file stores all output times in a single file along an ``ocean_time``
+   dimension whose length is fixed when the file is created. It therefore requires
+   ``remora.max_step`` and ``remora.plot_int`` :math:`> 0`, and does not support
+   ``remora.plot_int_time``; REMORA aborts at startup if these are not met. Set
+   ``remora.write_history_file = false`` to use a time-based output cadence, which writes
+   one NetCDF file per output step.
+
 -  Depending on your PnetCDF build, the code may be unable to write files larger than 2 GB. If the code
    crashes when writing a NetCDF history file (or a single time step, if you have a particularly large grid),
    consider building with MPICH v4.2.2 or instead outputting a native AMReX plotfile instead.
@@ -153,6 +160,7 @@ Notes
 
 -  If both ``remora.plot_int`` and ``remora.plot_int_time`` have been set, plotfile output will occur
    ``plot_int`` steps or ``plot_int_time`` simulation seconds after the last plotfile, whichever happens first.
+   This combination is not allowed when writing a NetCDF history file, as noted above.
 
 -  When Fennel biology is enabled, ``fennel`` in ``remora.plot_vars_3d``
    expands to all active biology tracers. Active biology tracers can also be

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -143,14 +143,21 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
     int ny = subdomain.length(1);
     int nz = subdomain.length(2);
 
-    if (is_history && max_step < 0) {
+    // ReadParameters already checks these; re-check because nt is derived just below.
+    if (is_history && !max_step_specified) {
         amrex::Abort("Need to know max_step if writing history file");
+    }
+    if (is_history && plot_int <= 0) {
+        amrex::Abort("Need remora.plot_int > 0 if writing history file");
     }
 
     long long int nt;
     if (is_history) {
         if (max_step > 0) {
-            nt = static_cast<long long int>(max_step / std::min(plot_int, max_step)) + 1;
+            // Writes happen at step 0, every plot_int steps, and once more at the
+            // final time if max_step is not a multiple of plot_int.
+            nt = static_cast<long long int>(max_step / plot_int) + 1
+               + static_cast<long long int>((max_step % plot_int != 0) ? 1 : 0);
         } else {
             nt = 1;
         }
@@ -939,6 +946,8 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             if (solverChoice.output_forcing)
             {
                 const Real Hscale = solverChoice.rho0 * Cp;
+                // The copy and the mult below are both async on the same stream, so the
+                // sync has to follow the last of them and precede the host-side put().
                 // Tair
                 {
                     FArrayBox tmp_Tair;
@@ -972,10 +981,10 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
                         1           // number of comps
                     );
 
-                    Gpu::streamSynchronize();
-
                     // Convert °C·m/s → W/m²
                     tmp.mult<RunOn::Device>(Hscale);
+
+                    Gpu::streamSynchronize();
 
                     auto nc_var = ncf.var("qnet");
                     nc_var.put(tmp.dataPtr(),
@@ -1007,10 +1016,11 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
                     FArrayBox tmp;
                     tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
                     tmp.template copy<RunOn::Device>((*vec_lhflx[lev])[mfi.index()], 0, 0, 1);
-                    Gpu::streamSynchronize();
 
                     // Convert °C·m/s → W/m²
                     tmp.mult<RunOn::Device>(Hscale);
+
+                    Gpu::streamSynchronize();
 
                     auto nc_var = ncf.var("latent");
                     nc_var.put(tmp.dataPtr(),
@@ -1022,10 +1032,11 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
                     FArrayBox tmp;
                     tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
                     tmp.template copy<RunOn::Device>((*vec_shflx[lev])[mfi.index()], 0, 0, 1);
-                    Gpu::streamSynchronize();
 
                     // Convert °C·m/s → W/m²
                     tmp.mult<RunOn::Device>(Hscale);
+
+                    Gpu::streamSynchronize();
 
                     auto nc_var = ncf.var("sensible");
                     nc_var.put(tmp.dataPtr(),
@@ -1037,10 +1048,11 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
                     FArrayBox tmp;
                     tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
                     tmp.template copy<RunOn::Device>((*vec_lrflx[lev])[mfi.index()], 0, 0, 1);
-                    Gpu::streamSynchronize();
 
                     // Convert °C·m/s → W/m²
                     tmp.mult<RunOn::Device>(Hscale);
+
+                    Gpu::streamSynchronize();
 
                     auto nc_var = ncf.var("lwrad");
                     nc_var.put(tmp.dataPtr(),

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1610,6 +1610,9 @@ private:
 
     /** \brief maximum number of steps */
     int max_step = std::numeric_limits<int>::max();
+    /** \brief Whether max_step was set in the inputs; the default above is not a
+     * distinguishable sentinel */
+    bool max_step_specified = false;
     /** \brief Time to stop */
     amrex::Real stop_time = std::numeric_limits<amrex::Real>::max();
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1680,6 +1680,7 @@ REMORA::ReadParameters ()
         if (remora_stop_time and noprefix_stop_time) {
             Abort("remora.stop_time and stop_time are both specified. Please use only one!");
         }
+        max_step_specified = noprefix_max_step or remora_max_step;
     }
 
     ParmParse pp(pp_prefix);
@@ -1823,6 +1824,20 @@ REMORA::ReadParameters ()
         pp.queryAdd("write_history_file",write_history_file);
         pp.queryAdd("chunk_history_file",chunk_history_file);
         pp.queryAdd("steps_per_history_file",steps_per_history_file);
+        // A history file's ocean_time dimension has a fixed length, declared when the
+        // header is written and derived from max_step and plot_int. Check here so a bad
+        // combination fails at startup rather than mid-run inside PnetCDF. See #606.
+        if (write_history_file) {
+            if (!max_step_specified) {
+                Abort("Need to set max_step if writing a NetCDF history file. Set remora.max_step, or set remora.write_history_file=false to write one NetCDF file per output step.");
+            }
+            if (plot_int <= 0) {
+                Abort("Need remora.plot_int > 0 if writing a NetCDF history file, since the length of the ocean_time dimension is fixed when the file is created. Set remora.write_history_file=false to write one NetCDF file per output step.");
+            }
+            if (plot_int_time > zero) {
+                Abort("remora.plot_int_time is not supported when writing a NetCDF history file, since the length of the ocean_time dimension is fixed when the file is created and a time-based output cadence cannot be predicted from max_step. Use remora.plot_int alone, or set remora.write_history_file=false to write one NetCDF file per output step.");
+            }
+        }
         // Estimate size of domain for one timestep of netcdf
         auto dom = geom[0].Domain();
         int nx = dom.length(0) + 2;
@@ -1842,8 +1857,8 @@ REMORA::ReadParameters ()
                 steps_per_history_file = 1;
             }
         } else if (write_history_file and !chunk_history_file) {
-            // Estimate number of output steps we'll need
-            int nt_out = int((max_step) / plot_int) + 1;
+            // Estimate number of output steps; must match ocean_time in WriteNCPlotFile_which
+            int nt_out = max_step / plot_int + 1 + ((max_step % plot_int != 0) ? 1 : 0);
             Real est_hist_file_size = NCH2D * nx * ny * double_bits + nt_out * nx * ny * double_bits * (NC3D*nz + NC2D);
             if (est_hist_file_size > two_gb) {
                 amrex::Warning("WARNING: NetCDF history file may be larger than 2GB limit. Consider setting remora.chunk_history_file=true");


### PR DESCRIPTION
Two defects in WriteNCPlotFile_which.

F003: in the four scaled-flux blocks (qnet, latent, sensible, lwrad) the streamSynchronize() sat between the async copy into pinned host memory and the async mult<RunOn::Device>(Hscale), so the host-side put() raced the scaling kernel. Move the sync after the mult; both share a stream, so one still covers each and no extra synchronization is added.

F020: ocean_time was sized max_step / min(plot_int, max_step) + 1, omitting the extra record WriteAtFinalTime writes when max_step is not a multiple of plot_int. With plot_int=3 and max_step=10 REMORA writes at steps 0, 3, 6, 9 and 10 but declared ocean_time = 4, so the final write aborted with "Index exceeds dimension bound" and that output was lost. Use the ceiling form.

The same expression went negative under plot_int_time, since plot_int stays -1. A time-based cadence cannot be predicted from max_step, and ocean_time is fixed length, so history output now requires max_step and plot_int > 0 and rejects plot_int_time. ReadParameters checks this so the run fails at startup rather than mid-run inside PnetCDF; write_history_file=false still supports a time-based cadence, one file per output step.

The replaced guard "is_history && max_step < 0" was unreachable: max_step defaults to numeric_limits<int>::max(), so an unset max_step built a garbage dimension length. Track whether it was set explicitly instead.

F019 from the same issue was already fixed by the arbitrary-tracer work.

Verified with a PnetCDF build of Exec/BoundaryLayer: plot_int=3, max_step=10 aborts before the change and gives ocean_time = 5 after; plot_int=5 gives exactly 3 records; chunking splits 5 records 2+2+1 with every dimension filled; the scaled fluxes sum consistently in W/m2. All 29 CPU regression tests pass.

Fixes #606 