### PR TITLE
Fix the CFL timestep estimate, and simplify the mode-split inputs

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -564,9 +564,11 @@ List of Parameters for Single-Rate
 |                               |                         |                |                            |
 |                               |                         | Values         |                            |
 +===============================+=========================+================+============================+
-| **remora.cfl**                | CFL number for          | Real > 0       | 0.8                        |
-|                               | hydro                   |                |                            |
-|                               |                         | and <= 1       |                            |
+| **remora.cfl**                | Courant number applied  | Real > 0       | 0.8                        |
+|                               | to the advective and    |                |                            |
+|                               | external gravity wave   | and <= 1       |                            |
+|                               | limits. Only used if    |                |                            |
+|                               | **fixed_dt** is unset   |                |                            |
 +-------------------------------+-------------------------+----------------+----------------------------+
 | **remora.fixed_dt**           | set level 0 dt          | Real > 0       | unused if                  |
 |                               |                         |                |                            |
@@ -604,7 +606,24 @@ Examples of Usage
 -----------------
 
 -  | **remora.cfl** = 0.9
-   | defines the timestep as dt = cfl \* dx / (u+c).  Only relevant if **fixed_dt** not set
+   | scales the estimated timestep, and is only relevant if **fixed_dt** is not set. The
+     estimate is the smaller of an advective limit and an external gravity wave limit,
+     each a maximum over the wet cells (``mskr`` > 0.5) of the level:
+   | ``dt_adv  = cfl / max( |u|*pm, |v|*pn, |w|/Hz )``
+   | ``dt_grav = cfl * ndtfast / max( sqrt(g*h) * sqrt(pm**2 + pn**2) )``
+   | ``dt      = min(dt_adv, dt_grav)``
+   | ``pm`` and ``pn`` are the per-cell 1/dx and 1/dy metrics, so stretched and
+     curvilinear grids are handled; ``Hz`` is the layer thickness and ``h`` the
+     bathymetry. ``ndtfast`` is **fixed_ndtfast_ratio** when **use_barotropic** is true
+     and 1 otherwise: the baroclinic step only has to resolve the external gravity wave
+     to within the number of barotropic substeps taken per baroclinic step.
+   | The gravity wave term is what keeps the estimate finite for a run started from rest,
+     where every velocity is zero. The estimate does **not** include the internal gravity
+     wave speed, so a large **fixed_ndtfast_ratio** can yield a baroclinic step that does
+     not resolve the internal modes; lower **remora.cfl** or set **remora.fixed_dt** in
+     that case. With **use_barotropic** = false the estimate is conservative in the other
+     direction, since it applies the full external-wave limit to a run that has no free
+     surface to propagate one.
 
 -  | **remora.change_max** = 1.1
    | allows the time step to increase by no more than 10% in this case.

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -580,18 +580,13 @@ List of Parameters for Single-Rate
 |                               | or other                |                |                            |
 |                               | settings                |                |                            |
 +-------------------------------+-------------------------+----------------+----------------------------+
-| **remora.fixed_fast_dt**      | set fast dt as this     | real > 0       | inferred from **fixed_dt** |
-|                               | value                   |                |                            |
-|                               |                         |                | and **fixed_ndfast_ratio** |
-|                               |                         |                |                            |
-|                               |                         |                | if not set                 |
-+-------------------------------+-------------------------+----------------+----------------------------+
-| **remora.fixed_ndfast_ratio** | set fast dt as          | int            | inferred from **fixed_dt** |
-|                               |                         |                |                            |
-|                               |                         |                | and **fixed_fast_dt**      |
-|                               |                         |                |                            |
-|                               | slow dt /               |                |                            |
-|                               | this ratio              |                | if not set                 |
+| **remora.ndtfast**            | number of barotropic    | int > 0        | must be set                |
+|                               | steps taken per         |                |                            |
+|                               | baroclinic step. The    |                |                            |
+|                               | fast dt is slow dt /    |                |                            |
+|                               | this ratio. Deprecated  |                |                            |
+|                               | alias:                  |                |                            |
+|                               | **fixed_ndtfast_ratio** |                |                            |
 +-------------------------------+-------------------------+----------------+----------------------------+
 | **remora.change_max**         | factor by which         | Real >= 1      | 1.1                        |
 |                               | dt can grow             |                |                            |
@@ -614,16 +609,14 @@ Examples of Usage
    | ``dt      = min(dt_adv, dt_grav)``
    | ``pm`` and ``pn`` are the per-cell 1/dx and 1/dy metrics, so stretched and
      curvilinear grids are handled; ``Hz`` is the layer thickness and ``h`` the
-     bathymetry. ``ndtfast`` is **fixed_ndtfast_ratio** when **use_barotropic** is true
-     and 1 otherwise: the baroclinic step only has to resolve the external gravity wave
-     to within the number of barotropic substeps taken per baroclinic step.
+     bathymetry. ``ndtfast`` is **remora.ndtfast**: the baroclinic step only has to
+     resolve the external gravity wave to within the number of barotropic substeps taken
+     per baroclinic step.
    | The gravity wave term is what keeps the estimate finite for a run started from rest,
      where every velocity is zero. The estimate does **not** include the internal gravity
-     wave speed, so a large **fixed_ndtfast_ratio** can yield a baroclinic step that does
-     not resolve the internal modes; lower **remora.cfl** or set **remora.fixed_dt** in
-     that case. With **use_barotropic** = false the estimate is conservative in the other
-     direction, since it applies the full external-wave limit to a run that has no free
-     surface to propagate one.
+     wave speed, so a large **remora.ndtfast** can yield a baroclinic step that does not
+     resolve the internal modes; lower **remora.cfl** or set **remora.fixed_dt** in that
+     case.
 
 -  | **remora.change_max** = 1.1
    | allows the time step to increase by no more than 10% in this case.
@@ -714,10 +707,6 @@ List of Parameters
 |                                  | debugging purposes.         |                   |             |
 +----------------------------------+-----------------------------+-------------------+-------------+
 | **remora.use_uv3dmix**           | Include harmonic viscosity. | true / false      | true        |
-|                                  |                             |                   |             |
-|                                  | Only for debugging purposes.|                   |             |
-+----------------------------------+-----------------------------+-------------------+-------------+
-| **remora.use_barotropic**        | Include 2d barotropic step. | true / false      | true        |
 |                                  |                             |                   |             |
 |                                  | Only for debugging purposes.|                   |             |
 +----------------------------------+-----------------------------+-------------------+-------------+

--- a/Exec/Advection/inputs
+++ b/Exec/Advection/inputs
@@ -15,7 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Advection/inputs
+++ b/Exec/Advection/inputs
@@ -15,9 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Advection/inputs_ml
+++ b/Exec/Advection/inputs_ml
@@ -15,9 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 100.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 10 # Baratropic timestep size (seconds)
+remora.ndtfast  = 10 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 10      # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Advection/inputs_ml
+++ b/Exec/Advection/inputs_ml
@@ -15,7 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 100.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 10 # Baratropic timestep size (seconds)
+remora.ndtfast  = 10
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 10      # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/BioToy/inputs
+++ b/Exec/BioToy/inputs
@@ -23,10 +23,9 @@ remora.is_periodic = 1 1 0
 #remora.bc.zeta.type   =  slipwall         periodic          outflow           periodic
 #remora.bc.tke.type    =  slipwall         periodic          outflow           periodic
 
-
 # TIME STEP CONTROL
 remora.fixed_dt       = 540.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 30
+remora.ndtfast = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/BlankProblem/inputs
+++ b/Exec/BlankProblem/inputs
@@ -14,7 +14,7 @@ remora.is_periodic = 1 1 0
 
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/BlankProblem/inputs
+++ b/Exec/BlankProblem/inputs
@@ -14,7 +14,7 @@ remora.is_periodic = 1 1 0
 
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
-remora.ndtfast  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/BoundaryLayer/inputs
+++ b/Exec/BoundaryLayer/inputs
@@ -23,10 +23,9 @@ remora.bc.vbar.type   =  slipwall         periodic          outflow           pe
 remora.bc.zeta.type   =  slipwall         periodic          outflow           periodic
 remora.bc.tke.type    =  slipwall         periodic          outflow           periodic
 
-
 # TIME STEP CONTROL
 remora.fixed_dt       = 50.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 30
+remora.ndtfast = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Channel_Test/inputs
+++ b/Exec/Channel_Test/inputs
@@ -18,9 +18,9 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 400.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 10
+remora.ndtfast = 10
 
-#remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+#remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Channel_Test/inputs_orlanski
+++ b/Exec/Channel_Test/inputs_orlanski
@@ -25,9 +25,9 @@ remora.bc.tke.type    =  outflow outflow outflow outflow
 # TIME STEP CONTROL
 remora.fixed_dt       = 400.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 10
+remora.ndtfast = 10
 
-#remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+#remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
@@ -69,7 +69,6 @@ remora.Zos = 0.002
 remora.Akk_bak = 5.0e-6
 remora.Akp_bak = 5.0e-6
 remora.Akv_bak = 1.0e-5
-
 
 # Linear EOS parameters
 remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State

--- a/Exec/CoupleToERF/inputs
+++ b/Exec/CoupleToERF/inputs
@@ -20,7 +20,7 @@ remora.is_periodic = 1 1 0
 
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
-remora.ndtfast  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/CoupleToERF/inputs
+++ b/Exec/CoupleToERF/inputs
@@ -20,7 +20,7 @@ remora.is_periodic = 1 1 0
 
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Dogbone/inputs
+++ b/Exec/Dogbone/inputs
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Dogbone/inputs
+++ b/Exec/Dogbone/inputs
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/DogboneAnalytic/inputs
+++ b/Exec/DogboneAnalytic/inputs
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/DogboneAnalytic/inputs
+++ b/Exec/DogboneAnalytic/inputs
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/DogboneAnalytic/inputs_ml
+++ b/Exec/DogboneAnalytic/inputs_ml
@@ -20,7 +20,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/DogboneAnalytic/inputs_ml
+++ b/Exec/DogboneAnalytic/inputs_ml
@@ -20,7 +20,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/DogboneAnalytic/inputs_ml_mid
+++ b/Exec/DogboneAnalytic/inputs_ml_mid
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/DogboneAnalytic/inputs_ml_mid
+++ b/Exec/DogboneAnalytic/inputs_ml_mid
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/DogboneAnalytic/inputs_ml_quad
+++ b/Exec/DogboneAnalytic/inputs_ml_quad
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/DogboneAnalytic/inputs_ml_quad
+++ b/Exec/DogboneAnalytic/inputs_ml_quad
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/DogboneAnalytic/inputs_orlanski_mask
+++ b/Exec/DogboneAnalytic/inputs_orlanski_mask
@@ -64,7 +64,7 @@ remora.bc.tke.type    =  slipwall    slipwall    outflow         slipwall
 # most of the first 600 s just to cross the basin at sqrt(g*h) ~ 9.9 m/s, and
 # the face does not begin radiating until well after it arrives.
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/DogboneAnalytic/inputs_orlanski_mask
+++ b/Exec/DogboneAnalytic/inputs_orlanski_mask
@@ -64,7 +64,7 @@ remora.bc.tke.type    =  slipwall    slipwall    outflow         slipwall
 # most of the first 600 s just to cross the basin at sqrt(g*h) ~ 9.9 m/s, and
 # the face does not begin radiating until well after it arrives.
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/DoubleGyre/inputs
+++ b/Exec/DoubleGyre/inputs
@@ -20,9 +20,9 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 3600.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 20
+remora.ndtfast = 20
 
-#remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+#remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
@@ -55,7 +55,6 @@ remora.Akt_bak = 1.0
 remora.theta_s = 0.0
 remora.theta_b = 0.0
 remora.tcline = 1e16
-
 
 # Linear EOS parameters
 remora.R0    = 1028.0  # background density value (Kg/m3) used in Linear Equation of State

--- a/Exec/DoublyPeriodic/inputs
+++ b/Exec/DoublyPeriodic/inputs
@@ -15,7 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/DoublyPeriodic/inputs
+++ b/Exec/DoublyPeriodic/inputs
@@ -15,9 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Generic/inputs_generic
+++ b/Exec/Generic/inputs_generic
@@ -82,7 +82,7 @@ remora.air_pressure = 1013.48
 # type=Real; method=queryAdd
 remora.air_temperature = 23.567
 
-# source: Source/REMORA_DataStruct.H:246
+# source: Source/REMORA_DataStruct.H:243
 # type=bool; method=queryAdd
 remora.atm2ocn_flux_mode = <UNKNOWN_DEFAULT>
 
@@ -102,19 +102,19 @@ remora.bdy_time_varname = <UNKNOWN_DEFAULT>
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_u_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1931
+# source: Source/REMORA.cpp:1977
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_ubar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1930
+# source: Source/REMORA.cpp:1976
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_v_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1932
+# source: Source/REMORA.cpp:1978
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_vbar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1933
+# source: Source/REMORA.cpp:1979
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_zeta_time_varname = <UNKNOWN_DEFAULT>
 
@@ -162,7 +162,7 @@ remora.boundary_per_variable = false
 # type=bool; method=queryAdd
 remora.bulk_fluxes = true
 
-# CFL number for
+# Courant number applied
 # type=Real; method=queryAdd
 remora.cfl = <UNKNOWN_DEFAULT>
 
@@ -170,19 +170,19 @@ remora.cfl = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.change_max = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1746
+# source: Source/REMORA.cpp:1754
 # type=string; method=queryAdd
 remora.check_file = chk
 
-# source: Source/REMORA.cpp:1747
+# source: Source/REMORA.cpp:1755
 # type=int; method=queryAdd
 remora.check_int = -57600
 
-# source: Source/REMORA.cpp:1748
+# source: Source/REMORA.cpp:1756
 # type=Real; method=queryAdd
 remora.check_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1815
+# source: Source/REMORA.cpp:1861
 # type=bool; method=queryAdd
 remora.chunk_history_file = <UNKNOWN_DEFAULT>
 
@@ -222,7 +222,7 @@ remora.coriolis_type = beta_plane
 # type=string; method=queryAdd
 remora.coupling_type = TwoWay
 
-# source: Source/REMORA.cpp:1765
+# source: Source/REMORA.cpp:1773
 # type=Vector<std::string>; method=queryarr
 remora.data_log = <UNKNOWN_DEFAULT>
 
@@ -250,7 +250,7 @@ remora.do_rivers_scalar = <UNKNOWN_DEFAULT>
 # type=bool; method=queryAdd
 remora.do_rivers_temp = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:279
+# source: Source/REMORA_DataStruct.H:276
 # type=bool; method=queryAdd
 remora.eminusp = true
 
@@ -258,7 +258,7 @@ remora.eminusp = true
 # type=bool; method=queryAdd
 remora.eminusp_correct_ssh = true
 
-# source: Source/REMORA_DataStruct.H:275
+# source: Source/REMORA_DataStruct.H:272
 # type=Real; method=query
 remora.eminusp_value = <UNKNOWN_DEFAULT>
 
@@ -266,7 +266,7 @@ remora.eminusp_value = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.eos_type = linear
 
-# source: Source/REMORA.cpp:1749
+# source: Source/REMORA.cpp:1757
 # type=bool; method=queryAdd
 remora.expand_plotvars_to_unif_rr = <UNKNOWN_DEFAULT>
 
@@ -466,7 +466,7 @@ remora.fennel.wPhy = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.fennel.wSDet = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1773
+# source: Source/REMORA.cpp:1781
 # type=int; method=queryAdd
 remora.file_min_digits = 5
 
@@ -474,11 +474,7 @@ remora.file_min_digits = 5
 # type=Real; method=queryAdd
 remora.fixed_dt = 300.0
 
-# set fast dt as this
-# type=Real; method=queryAdd
-remora.fixed_fast_dt = 10.0
-
-# source: Source/REMORA.cpp:1783
+# Deprecated alias for remora.ndtfast.
 # type=int; method=queryAdd
 remora.fixed_ndtfast_ratio = 0
 
@@ -502,35 +498,35 @@ remora.gls_N = -1.0
 # type=Real; method=queryAdd
 remora.gls_P = 3.0
 
-# source: Source/REMORA_DataStruct.H:691
+# source: Source/REMORA_DataStruct.H:688
 # type=Real; method=queryAdd
 remora.gls_Pmin = 1.0e-12
 
-# source: Source/REMORA_DataStruct.H:694
+# source: Source/REMORA_DataStruct.H:691
 # type=Real; method=queryAdd
 remora.gls_c1 = 1.44
 
-# source: Source/REMORA_DataStruct.H:695
+# source: Source/REMORA_DataStruct.H:692
 # type=Real; method=queryAdd
 remora.gls_c2 = 1.92
 
-# source: Source/REMORA_DataStruct.H:696
+# source: Source/REMORA_DataStruct.H:693
 # type=Real; method=queryAdd
 remora.gls_c3m = -0.4
 
-# source: Source/REMORA_DataStruct.H:697
+# source: Source/REMORA_DataStruct.H:694
 # type=Real; method=queryAdd
 remora.gls_c3p = 1.0
 
-# source: Source/REMORA_DataStruct.H:693
+# source: Source/REMORA_DataStruct.H:690
 # type=Real; method=queryAdd
 remora.gls_cmu0 = 0.5477
 
-# source: Source/REMORA_DataStruct.H:698
+# source: Source/REMORA_DataStruct.H:695
 # type=Real; method=queryAdd
 remora.gls_sigk = 1.0
 
-# source: Source/REMORA_DataStruct.H:699
+# source: Source/REMORA_DataStruct.H:696
 # type=Real; method=queryAdd
 remora.gls_sigp = 1.3
 
@@ -558,7 +554,7 @@ remora.hires_init_level = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.horizontal_mixing_type = analytic
 
-# source: Source/REMORA_DataStruct.H:440
+# source: Source/REMORA_DataStruct.H:437
 # type=string; method=queryAdd
 remora.ic_bc_type = analytic
 
@@ -566,15 +562,15 @@ remora.ic_bc_type = analytic
 # type=string; method=queryAdd
 remora.ic_type = analytic
 
-# source: Source/REMORA_DataStruct.H:203
+# source: Source/REMORA_DataStruct.H:200
 # type=bool; method=queryAdd
 remora.init_ana_T = true
 
-# source: Source/REMORA_DataStruct.H:205
+# source: Source/REMORA_DataStruct.H:202
 # type=bool; method=queryAdd
 remora.init_l0int_T = false
 
-# source: Source/REMORA_DataStruct.H:201
+# source: Source/REMORA_DataStruct.H:198
 # type=bool; method=queryAdd
 remora.init_l1ad_T = false
 
@@ -598,15 +594,15 @@ remora.longwave_netcdf_varname = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.longwave_radiation_flux = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:268
+# source: Source/REMORA_DataStruct.H:265
 # type=Real; method=query
 remora.lwrad = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:736
+# source: Source/REMORA_DataStruct.H:733
 # type=Real; method=queryAdd
 remora.m2nudg = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:737
+# source: Source/REMORA_DataStruct.H:734
 # type=Real; method=queryAdd
 remora.m3nudg = <UNKNOWN_DEFAULT>
 
@@ -674,7 +670,11 @@ remora.nc_init_file_hires = <UNKNOWN_DEFAULT>
 # type=Vector<std::string>; method=queryarr
 remora.nc_river_file = "idRiv_riv_v0.2_classic64.nc"
 
-# source: Source/REMORA.cpp:1751
+# Number of barotropic (fast) steps taken per baroclinic (slow) step.
+# type=int; method=queryAdd
+remora.ndtfast = 0
+
+# source: Source/REMORA.cpp:1759
 # type=Real; method=query
 remora.netcdf_fill_value = <UNKNOWN_DEFAULT>
 
@@ -682,7 +682,7 @@ remora.netcdf_fill_value = <UNKNOWN_DEFAULT>
 # type=int; method=queryAdd
 remora.nscalar = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:738
+# source: Source/REMORA_DataStruct.H:735
 # type=Real; method=queryAdd
 remora.obcfac = <UNKNOWN_DEFAULT>
 
@@ -694,31 +694,31 @@ remora.omp_tile_size = 8 8 1024000
 # type=bool; method=queryAdd
 remora.output_forcing = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1801
+# source: Source/REMORA.cpp:1847
 # type=string; method=queryAdd
 remora.plot_file = plt
 
-# source: Source/REMORA.cpp:1802
+# source: Source/REMORA.cpp:1848
 # type=int; method=queryAdd
 remora.plot_int = 100
 
-# source: Source/REMORA.cpp:1803
+# source: Source/REMORA.cpp:1849
 # type=Real; method=queryAdd
 remora.plot_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1805
+# source: Source/REMORA.cpp:1851
 # type=bool; method=query
 remora.plot_nodal_data = true
 
-# source: Source/REMORA.cpp:1804
+# source: Source/REMORA.cpp:1850
 # type=bool; method=query
 remora.plot_staggered_vels = false
 
-# source: Source/REMORA.cpp:1750
+# source: Source/REMORA.cpp:1758
 # type=Real; method=query
 remora.plotfile_fill_value = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1808
+# source: Source/REMORA.cpp:1854
 # type=string; method=queryAdd
 remora.plotfile_type = amrex
 
@@ -830,7 +830,7 @@ remora.refinement_indicators_.value_greater = <REQUIRED>
 # type=Real; method=getarr
 remora.refinement_indicators_.value_less = <REQUIRED>
 
-# source: Source/REMORA.cpp:1752
+# source: Source/REMORA.cpp:1760
 # type=string; method=queryAdd
 remora.restart = <UNKNOWN_DEFAULT>
 
@@ -854,7 +854,7 @@ remora.smflux_type = analytic
 # type=Real; method=queryAdd
 remora.start_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1816
+# source: Source/REMORA.cpp:1862
 # type=int; method=queryAdd
 remora.steps_per_history_file = <UNKNOWN_DEFAULT>
 
@@ -866,7 +866,7 @@ remora.stop_time = 30000.0
 # type=int; method=queryAdd
 remora.sum_interval = -1
 
-# source: Source/REMORA.cpp:1772
+# source: Source/REMORA.cpp:1780
 # type=Real; method=queryAdd
 remora.sum_period = <UNKNOWN_DEFAULT>
 
@@ -914,10 +914,6 @@ remora.tnudg = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.tracer_horizontal_advection_scheme = upstream3
 
-# This accounts for the main 2d loop but may not include coupling and copying properly
-# type=bool; method=queryAdd
-remora.use_barotropic = <UNKNOWN_DEFAULT>
-
 # Bridge-vs-native selection and diagnostic verbosity are runtime controls so a parity comparison never requires a rebuild. Both parse unconditionally; without USE_FENNEL_FORT there is no bridge to select, so asking for it is an error rather than a silent fallback to the path being validated.
 # type=int; method=queryAdd
 remora.use_biology_cpp_answer = <UNKNOWN_DEFAULT>
@@ -926,7 +922,7 @@ remora.use_biology_cpp_answer = <UNKNOWN_DEFAULT>
 # type=bool; method=queryAdd
 remora.use_coriolis = true
 
-# This accounts for the main 2d loop but may not include coupling and copying properly
+# This affect forcing and some of the mixing terms for velocity
 # type=bool; method=queryAdd
 remora.use_curvilinear_grid = <UNKNOWN_DEFAULT>
 
@@ -970,11 +966,11 @@ remora.vwind = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.wind_type = analytic
 
-# source: Source/REMORA.cpp:1814
+# source: Source/REMORA.cpp:1860
 # type=bool; method=queryAdd
 remora.write_history_file = true
 
-# source: Source/REMORA_DataStruct.H:735
+# source: Source/REMORA_DataStruct.H:732
 # type=Real; method=queryAdd
 remora.znudg = <UNKNOWN_DEFAULT>
 
@@ -1816,7 +1812,7 @@ blprofiler.prof_traceflushsize = <UNKNOWN_DEFAULT>
 #==============================================================================
 # DRIVER PARAMETERS
 #==============================================================================
-# source: Source/REMORA_DataStruct.H:250
+# source: Source/REMORA_DataStruct.H:247
 # type=string; method=query
 driver.atm2ocn_mode = state
 

--- a/Exec/Generic/remora_value_hints.json
+++ b/Exec/Generic/remora_value_hints.json
@@ -196,14 +196,6 @@
       "value": "300.0",
       "count": 35
     },
-    "remora.fixed_fast_dt": {
-      "value": "10.0",
-      "count": 28
-    },
-    "remora.fixed_ndtfast_ratio": {
-      "value": "30",
-      "count": 35
-    },
     "remora.gls_Kmin": {
       "value": "7.6e-6",
       "count": 7
@@ -327,6 +319,10 @@
     "remora.nc_river_file": {
       "value": "\"idRiv_riv_v0.2_classic64.nc\"",
       "count": 7
+    },
+    "remora.ndtfast": {
+      "value": "30",
+      "count": 35
     },
     "remora.omp_tile_size": {
       "value": "8 8 1024",

--- a/Exec/GulfRefinementTest/inputs_cf_orlanski
+++ b/Exec/GulfRefinementTest/inputs_cf_orlanski
@@ -28,7 +28,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 40.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/GulfRefinementTest/inputs_cf_orlanski
+++ b/Exec/GulfRefinementTest/inputs_cf_orlanski
@@ -28,7 +28,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 40.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Exec/GulfRefinementTest/inputs_outflow
+++ b/Exec/GulfRefinementTest/inputs_outflow
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 40.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 # Level 1 has to exist for the high-resolution data to be evaluated on and averaged down from,

--- a/Exec/GulfRefinementTest/inputs_outflow
+++ b/Exec/GulfRefinementTest/inputs_outflow
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 40.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 # Level 1 has to exist for the high-resolution data to be evaluated on and averaged down from,

--- a/Exec/IdealMiniGrid/inputs
+++ b/Exec/IdealMiniGrid/inputs
@@ -19,7 +19,7 @@ remora.bc.yhi.type = "clamped"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 1 # Baratropic timestep size (seconds)
+remora.ndtfast = 1 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs
+++ b/Exec/IdealMiniGrid/inputs
@@ -19,7 +19,7 @@ remora.bc.yhi.type = "clamped"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.ndtfast = 1 # Baratropic timestep size (seconds)
+remora.ndtfast = 1
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_cf_orlanski
+++ b/Exec/IdealMiniGrid/inputs_cf_orlanski
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_cf_orlanski
+++ b/Exec/IdealMiniGrid/inputs_cf_orlanski
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_chapman_flather
+++ b/Exec/IdealMiniGrid/inputs_chapman_flather
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow  outflow  outflow  outflow
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_chapman_flather
+++ b/Exec/IdealMiniGrid/inputs_chapman_flather
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow  outflow  outflow  outflow
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_clim_nudg
+++ b/Exec/IdealMiniGrid/inputs_clim_nudg
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2000.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_clim_nudg
+++ b/Exec/IdealMiniGrid/inputs_clim_nudg
@@ -29,7 +29,7 @@ remora.bc.tke.type    =  outflow           outflow           outflow          ou
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2000.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_frc
+++ b/Exec/IdealMiniGrid/inputs_frc
@@ -19,7 +19,7 @@ remora.bc.yhi.type = "clamped"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 1 # Baratropic timestep size (seconds)
+remora.ndtfast = 1 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_frc
+++ b/Exec/IdealMiniGrid/inputs_frc
@@ -19,7 +19,7 @@ remora.bc.yhi.type = "clamped"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 200.0 # Timestep size (seconds)
-remora.ndtfast = 1 # Baratropic timestep size (seconds)
+remora.ndtfast = 1
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealMiniGrid/inputs_synth_hires
+++ b/Exec/IdealMiniGrid/inputs_synth_hires
@@ -32,7 +32,7 @@ remora.bc.yhi.type = "outflow"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 1.0
-remora.fixed_ndtfast_ratio = 10
+remora.ndtfast = 10
 
 # REFINEMENT
 # Level 1 has to exist for the high-resolution data to live on. No refinement indicator is set,

--- a/Exec/IdealRivGrid/inputs
+++ b/Exec/IdealRivGrid/inputs
@@ -21,7 +21,7 @@ remora.bc.yhi.type = "clamped"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 4000.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 10 # Baratropic timestep size (seconds)
+remora.ndtfast = 10 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/IdealRivGrid/inputs
+++ b/Exec/IdealRivGrid/inputs
@@ -21,7 +21,7 @@ remora.bc.yhi.type = "clamped"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 4000.0 # Timestep size (seconds)
-remora.ndtfast = 10 # Baratropic timestep size (seconds)
+remora.ndtfast = 10
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/ParticleAdvectionFlat/inputs
+++ b/Exec/ParticleAdvectionFlat/inputs
@@ -15,9 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30 # Baratropic timestep size (seconds)
 
 # PARTICLES
 remora.use_tracer_particles = 1

--- a/Exec/ParticleAdvectionFlat/inputs
+++ b/Exec/ParticleAdvectionFlat/inputs
@@ -15,7 +15,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30
 
 # PARTICLES
 remora.use_tracer_particles = 1

--- a/Exec/Seamount/inputs
+++ b/Exec/Seamount/inputs
@@ -16,7 +16,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Seamount/inputs
+++ b/Exec/Seamount/inputs
@@ -16,9 +16,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Upwelling/inputs
+++ b/Exec/Upwelling/inputs
@@ -19,9 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-#remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Upwelling/inputs_fennel
+++ b/Exec/Upwelling/inputs_fennel
@@ -31,9 +31,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Exec/Upwelling/inputs_fennel_hires
+++ b/Exec/Upwelling/inputs_fennel_hires
@@ -26,9 +26,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Exec/Upwelling/inputs_gls
+++ b/Exec/Upwelling/inputs_gls
@@ -17,9 +17,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Exec/Upwelling_Coupling/inputs
+++ b/Exec/Upwelling_Coupling/inputs
@@ -19,9 +19,7 @@ remora.bc.xhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-#remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Exec/Upwelling_ML/inputs
+++ b/Exec/Upwelling_ML/inputs
@@ -14,9 +14,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 5 # Timestep size (seconds)
 
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 1 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 1 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1658,10 +1658,8 @@ private:
     static amrex::Real change_max;
     /** \brief User specified fixed baroclinic time step */
     static amrex::Real fixed_dt;
-    /** \brief User specified fixed barotropic time step */
-    static amrex::Real fixed_fast_dt;
     /** \brief User specified, number of barotropic steps per baroclinic step */
-    static int fixed_ndtfast_ratio;
+    static int ndtfast;
     /** \brief Number of fast steps to take */
     int nfast;
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1991,6 +1991,20 @@ REMORA::ReadParameters ()
     }
     solverChoice.init_params(ncons, nscalar, cons_names);
 
+    // Advance and timeStepML form the fast step as dt / fixed_ndtfast_ratio, and
+    // set_weights sizes the barotropic filter with the same number. The inference above
+    // only runs when both fixed_dt and fixed_fast_dt are given, so every other barotropic
+    // configuration must state the ratio outright or those sites divide by zero. In
+    // particular there is nothing to infer it from when dt comes from remora.cfl, since
+    // dt is not known until run time. This has to sit after init_params, which is where
+    // use_barotropic is parsed.
+    if (solverChoice.use_barotropic && fixed_ndtfast_ratio <= 0) {
+        amrex::Abort("remora.fixed_ndtfast_ratio must be a positive integer when "
+                     "remora.use_barotropic is true. It is inferred only when both "
+                     "remora.fixed_dt and remora.fixed_fast_dt are set; otherwise set it "
+                     "explicitly, or set remora.use_barotropic = false");
+    }
+
     // The biology IC source is chosen independently of ic_type, but only one of the two
     // mixed combinations works: NetCDF physics with analytic biology. The reverse has no
     // file to read from -- nc_init_file is only populated on the netcdf path -- so catch

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -23,10 +23,9 @@ SolverChoice REMORA::solverChoice;
 // Time step control
 amrex::Real REMORA::cfl           =  Real(0.8);
 amrex::Real REMORA::fixed_dt      = -one;
-amrex::Real REMORA::fixed_fast_dt = -one;
 amrex::Real REMORA::change_max    =  Real(1.1);
 
-int   REMORA::fixed_ndtfast_ratio = 0;
+int   REMORA::ndtfast             = 0;
 
 // Dictate verbosity in screen output
 int         REMORA::verbose       = 0;
@@ -1776,16 +1775,54 @@ REMORA::ReadParameters ()
     pp.queryAdd("cfl", cfl);
     pp.queryAdd("change_max", change_max);
     pp.queryAdd("fixed_dt", fixed_dt);
-    pp.queryAdd("fixed_fast_dt", fixed_fast_dt);
-    pp.queryAdd("fixed_ndtfast_ratio", fixed_ndtfast_ratio);
 
-    if (fixed_dt > zero && fixed_fast_dt > zero && fixed_ndtfast_ratio > 0) {
-        if (fixed_dt / fixed_fast_dt != fixed_ndtfast_ratio) {
-            amrex::Abort("Dt is over-specfied");
-        }
-    } else if (fixed_dt > zero && fixed_fast_dt > zero && fixed_ndtfast_ratio <= 0) {
-        fixed_ndtfast_ratio = static_cast<int>(fixed_dt / fixed_fast_dt);
+    // remora.fixed_fast_dt has been removed. It only ever served to infer the number of
+    // barotropic substeps, and only when remora.fixed_dt was also given -- which left the
+    // ratio at zero on every other path, including a CFL-driven run. amrex does not abort
+    // on unused inputs by default, so catch it here rather than letting a stale input file
+    // silently fall back to whatever remora.ndtfast happens to be.
+    if (pp.contains("fixed_fast_dt")) {
+        amrex::Abort("remora.fixed_fast_dt has been removed. Set remora.ndtfast (the "
+                     "number of barotropic steps per baroclinic step) instead; it is what "
+                     "fixed_fast_dt was used to infer, as remora.fixed_dt / "
+                     "remora.fixed_fast_dt");
     }
+
+    // remora.ndtfast is the preferred name; remora.fixed_ndtfast_ratio is kept as a
+    // deprecated alias so existing input files keep working. Read the alias first, so
+    // that the queryAdd below records the resulting value under the preferred name.
+    if (pp.contains("fixed_ndtfast_ratio")) {
+        if (pp.contains("ndtfast")) {
+            amrex::Abort("remora.ndtfast and remora.fixed_ndtfast_ratio are both "
+                         "specified. Please use only remora.ndtfast");
+        }
+        amrex::Print() << "WARNING: remora.fixed_ndtfast_ratio is deprecated. "
+                       << "Please use remora.ndtfast instead." << std::endl;
+        // Deprecated alias for remora.ndtfast.
+        pp.queryAdd("fixed_ndtfast_ratio", ndtfast);
+    }
+    // Number of barotropic (fast) steps taken per baroclinic (slow) step.
+    pp.queryAdd("ndtfast", ndtfast);
+
+    // Advance and timeStepML form the fast step as dt / ndtfast, and set_weights sizes
+    // the barotropic filter with the same number, so a non-positive value divides by zero
+    // at all three sites. Nothing can infer it: dt is not known until run time on a
+    // CFL-driven run.
+    if (ndtfast <= 0) {
+        amrex::Abort("remora.ndtfast must be a positive integer: it is the number of "
+                     "barotropic steps taken per baroclinic step");
+    }
+
+    // remora.use_barotropic has been removed -- the barotropic mode is always on. Reject
+    // it on presence rather than on value: amrex does not abort on unused inputs by
+    // default, so a stale "= false" would otherwise silently run different physics than
+    // the input file asks for. Tested with contains() rather than query() so the schema
+    // scraper behind Exec/Generic does not re-advertise a parameter that no longer exists.
+    if (pp.contains("use_barotropic")) {
+        amrex::Abort("remora.use_barotropic has been removed. The barotropic (2D) mode is "
+                     "always active; please delete this line from your inputs file");
+    }
+
     AMREX_ASSERT(cfl > zero || fixed_dt > zero);
 
     num_files_at_level.resize(max_level + 1, 0);
@@ -1990,20 +2027,6 @@ REMORA::ReadParameters ()
 
     }
     solverChoice.init_params(ncons, nscalar, cons_names);
-
-    // Advance and timeStepML form the fast step as dt / fixed_ndtfast_ratio, and
-    // set_weights sizes the barotropic filter with the same number. The inference above
-    // only runs when both fixed_dt and fixed_fast_dt are given, so every other barotropic
-    // configuration must state the ratio outright or those sites divide by zero. In
-    // particular there is nothing to infer it from when dt comes from remora.cfl, since
-    // dt is not known until run time. This has to sit after init_params, which is where
-    // use_barotropic is parsed.
-    if (solverChoice.use_barotropic && fixed_ndtfast_ratio <= 0) {
-        amrex::Abort("remora.fixed_ndtfast_ratio must be a positive integer when "
-                     "remora.use_barotropic is true. It is inferred only when both "
-                     "remora.fixed_dt and remora.fixed_fast_dt are set; otherwise set it "
-                     "explicitly, or set remora.use_barotropic = false");
-    }
 
     // The biology IC source is chosen independently of ic_type, but only one of the two
     // mixed combinations works: NetCDF physics with analytic biology. The reverse has no

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -168,9 +168,6 @@ struct SolverChoice {
         //This affect forcing and some of the mixing terms for velocity
         pp.queryAdd("use_uv3dmix", use_uv3dmix);
 
-        //This accounts for the main 2d loop but may not include coupling and copying properly
-        pp.queryAdd("use_barotropic", use_barotropic);
-
         pp.queryAdd("use_curvilinear_grid", use_curvilinear_grid);
 
         // Whether to do rivers. By default, rivers are temp and salt sources. Rivers
@@ -786,7 +783,6 @@ struct SolverChoice {
         amrex::Print() << "use_coriolis          : " << use_coriolis << std::endl;
         amrex::Print() << "use_prestep           : " << use_prestep << std::endl;
         amrex::Print() << "use_uv3dmix           : " << use_uv3dmix << std::endl;
-        amrex::Print() << "use_barotropic        : " << use_barotropic << std::endl;
         amrex::Print() << "spatial_order         : " << spatial_order << std::endl;
 
         if (ic_type == IC_Type::analytic) {
@@ -845,7 +841,6 @@ struct SolverChoice {
     bool        use_prestep           = true;
     bool        use_uv3dmix           = true;
     bool        use_baroclinic        = true;
-    bool        use_barotropic        = true;
 
     bool        use_curvilinear_grid  = false;
 

--- a/Source/TimeIntegration/REMORA_Advance.cpp
+++ b/Source/TimeIntegration/REMORA_Advance.cpp
@@ -20,21 +20,18 @@ REMORA::Advance (int lev, Real time, Real dt_lev, int /*iteration*/, int /*ncycl
 
     setup_step(lev, time, dt_lev);
 
-    if (solverChoice.use_barotropic)
-    {
-        int nfast_counter=nfast + 1;
+    int nfast_counter=nfast + 1;
 
-        //***************************************************
-        //Compute fast timestep from dt_lev and ratio
-        //***************************************************
-        Real dtfast_lev=dt_lev/Real(fixed_ndtfast_ratio);
+    //***************************************************
+    //Compute fast timestep from dt_lev and ratio
+    //***************************************************
+    Real dtfast_lev=dt_lev/Real(ndtfast);
 
-        //***************************************************
-        //Advance nfast_counter steps of the 2d integrator
-        //***************************************************
-        for (int my_iif = 0; my_iif < nfast_counter; my_iif++) {
-            advance_2d_onestep(lev, dt_lev, dtfast_lev, my_iif, nfast_counter);
-        }
+    //***************************************************
+    //Advance nfast_counter steps of the 2d integrator
+    //***************************************************
+    for (int my_iif = 0; my_iif < nfast_counter; my_iif++) {
+        advance_2d_onestep(lev, dt_lev, dtfast_lev, my_iif, nfast_counter);
     }
 
 #ifdef REMORA_USE_FUNWAVE_FORT

--- a/Source/TimeIntegration/REMORA_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/REMORA_ComputeTimestep.cpp
@@ -70,14 +70,9 @@ REMORA::estTimeStep(int level) const
 {
     BL_PROFILE("REMORA::estTimeStep()");
 
-    // The barotropic mode is substepped fixed_ndtfast_ratio times per baroclinic step
+    // The barotropic mode is substepped ndtfast times per baroclinic step
     // (REMORA_Advance.cpp), so the slow step only has to resolve the external gravity
-    // wave to within that ratio. Without mode splitting there are no substeps to hide
-    // behind and the slow step carries the full external-wave constraint. ReadParameters
-    // rejects a non-positive ratio on the barotropic path; fall back to the restrictive
-    // choice rather than multiplying dt by zero should it somehow not be set.
-    const int ndtfast = (solverChoice.use_barotropic && fixed_ndtfast_ratio > 0)
-                      ? fixed_ndtfast_ratio : 1;
+    // wave to within that ratio. ReadParameters guarantees ndtfast is positive.
 
     // g is a file-scope constexpr; hoist it into a local for the device lambda.
     const Real grav = g;

--- a/Source/TimeIntegration/REMORA_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/REMORA_ComputeTimestep.cpp
@@ -1,5 +1,7 @@
 #include <REMORA.H>
 
+#include <cmath>
+
 using namespace amrex;
 
 void
@@ -22,6 +24,17 @@ REMORA::ComputeDt ()
         dt_0 = amrex::min(dt_0, n_factor*dt_tmp[lev]);
     }
 
+    // dt_0 is identical on every rank here, so this aborts collectively. The
+    // bogus_large_value test is the load-bearing one: the sentinel used to survive to
+    // this point intact whenever stop_time was left at its default of Real::max(), and to
+    // be laundered into stop_time - t_new[0] -- a single step covering the entire run --
+    // whenever stop_time was set. The change_max cap above cannot catch either case,
+    // since dt[] is itself seeded to bogus_large_value.
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dt_0 > zero && std::isfinite(dt_0) &&
+                                     dt_0 < bogus_large_value,
+                                     "REMORA::ComputeDt: computed a non-positive, "
+                                     "non-finite, or unusably large level-0 dt");
+
     // Limit dt's by the value of stop_time.
     const Real eps = Real(1.e-3)*dt_0;
     if (t_new[0] + dt_0 > stop_time - eps) {
@@ -35,6 +48,21 @@ REMORA::ComputeDt ()
 }
 
 /**
+ * Estimate the largest stable slow (baroclinic) timestep on a level.
+ *
+ * The estimate is the smaller of an advective limit and an external gravity wave limit,
+ * each a maximum over the wet cells of the level:
+ *
+ *     dt_adv  = cfl / max( |u|*pm, |v|*pn, |w|/Hz )
+ *     dt_grav = cfl * ndtfast / max( sqrt(g*|h|) * sqrt(pm^2 + pn^2) )
+ *
+ * The second is the Courant quantity ROMS forms as Cg_max in metrics.F. It is what keeps
+ * the estimate finite for a run started from rest, where every velocity is zero and the
+ * advective limit alone is undefined.
+ *
+ * pm and pn are the per-cell 1/dx and 1/dy metric terms rather than the geometry's
+ * uniform cell size, so stretched and curvilinear grids give the right answer.
+ *
  * @param[in] level    level of refinement
  */
 Real
@@ -42,56 +70,132 @@ REMORA::estTimeStep(int level) const
 {
     BL_PROFILE("REMORA::estTimeStep()");
 
-    amrex::Real estdt_lowM = bogus_large_value;
+    // The barotropic mode is substepped fixed_ndtfast_ratio times per baroclinic step
+    // (REMORA_Advance.cpp), so the slow step only has to resolve the external gravity
+    // wave to within that ratio. Without mode splitting there are no substeps to hide
+    // behind and the slow step carries the full external-wave constraint. ReadParameters
+    // rejects a non-positive ratio on the barotropic path; fall back to the restrictive
+    // choice rather than multiplying dt by zero should it somehow not be set.
+    const int ndtfast = (solverChoice.use_barotropic && fixed_ndtfast_ratio > 0)
+                      ? fixed_ndtfast_ratio : 1;
 
-    auto const dxinv = geom[level].InvCellSizeArray();
+    // g is a file-scope constexpr; hoist it into a local for the device lambda.
+    const Real grav = g;
 
     MultiFab ccvel(grids[level],dmap[level],3,0);
 
     average_face_to_cellcenter(ccvel,0,
         Array<const MultiFab*,3>{xvel_new[level], yvel_new[level], zvel_new[level]});
 
-    Real estdt_lowM_inv = amrex::ReduceMax(ccvel, 0,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& b,
-                                   Array4<Real const> const& u) -> Real
-        {
-            Real new_lm_dt = Real(-1.e100);
-            amrex::Loop(b, [=,&new_lm_dt] (int i, int j, int k) noexcept
-            {
-                new_lm_dt = amrex::max(((amrex::Math::abs(u(i,j,k,0)))*dxinv[0]),
-                                       ((amrex::Math::abs(u(i,j,k,1)))*dxinv[1]),
-                                       ((amrex::Math::abs(u(i,j,k,2)))*dxinv[2]), new_lm_dt);
-            });
-            return new_lm_dt;
-        });
+    // Two maxima over the same cells. amrex::ReduceMax's FabArray overloads take at most
+    // three FabArrays and this needs six, so drive ReduceOps directly. Unlike
+    // amrex::ReduceMax, ReduceOps::eval has no host fallback in a GPU build, so no
+    // Gpu::LaunchSafeGuard is wanted here.
+    ReduceOps<ReduceOpMax, ReduceOpMax> reduce_op;
+    ReduceData<Real, Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
-    ParallelDescriptor::ReduceRealMax(estdt_lowM_inv);
-    if (estdt_lowM_inv > zero)
-        estdt_lowM = cfl / estdt_lowM_inv;;
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for ( MFIter mfi(ccvel, TilingIfNotGPU()); mfi.isValid(); ++mfi )
+    {
+        // ccvel carries no ghost cells, so this is exactly its valid region -- the same
+        // cells the advective estimate has always visited.
+        const Box& bx = mfi.tilebox();
+
+        Array4<Real const> const& u    = ccvel.const_array(mfi);
+        Array4<Real const> const& Hz   = vec_Hz[level]->const_array(mfi);
+
+        // h, pm, pn and mskr live on the z-slab BoxArray built box-for-box from
+        // grids[level] with the same DistributionMapping, so they index off this same
+        // MFIter and are read at k = 0.
+        Array4<Real const> const& h    = vec_h[level]->const_array(mfi);
+        Array4<Real const> const& pm   = vec_pm[level]->const_array(mfi);
+        Array4<Real const> const& pn   = vec_pn[level]->const_array(mfi);
+        Array4<Real const> const& mskr = vec_mskr[level]->const_array(mfi);
+
+        reduce_op.eval(bx, reduce_data,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+        {
+            // Land contributes nothing: h there is a fill depth, not a real one.
+            if (mskr(i,j,0) <= Real(0.5)) { return {zero, zero}; }
+
+            Real inv_adv = amrex::max(amrex::Math::abs(u(i,j,k,0)) * pm(i,j,0),
+                                      amrex::Math::abs(u(i,j,k,1)) * pn(i,j,0));
+
+            // Hz is the true thickness of this terrain-following layer; the geometry's
+            // uniform dz is the thickness of a sigma level, not of a cell.
+            if (Hz(i,j,k) > zero) {
+                inv_adv = amrex::max(inv_adv, amrex::Math::abs(u(i,j,k,2)) / Hz(i,j,k));
+            }
+
+            // Component 0 of vec_h is the bathymetry, positive down. Component 1 is not a
+            // second copy of it -- stretch_transform overwrites it with the bottom z_w.
+            const Real c      = std::sqrt(grav * amrex::Math::abs(h(i,j,0,0)));
+            const Real inv_bt = c * std::sqrt(pm(i,j,0)*pm(i,j,0) + pn(i,j,0)*pn(i,j,0));
+
+            return {inv_adv, inv_bt};
+        });
+    } // mfi
+
+    ReduceTuple host_tuple = reduce_data.value(reduce_op);
+
+    // A rank owning no boxes never calls eval and leaves its local maxima at
+    // std::numeric_limits<Real>::lowest(); the MPI max repairs that, and every test below
+    // is against the reduced values, which are identical on every rank.
+    Real inv[2] = { amrex::get<0>(host_tuple), amrex::get<1>(host_tuple) };
+    ParallelDescriptor::ReduceRealMax(inv, 2);
+    const Real inv_adv = inv[0];
+    const Real inv_bt  = inv[1];
+
+    // Guard both divisions rather than letting them produce inf: inv_adv is zero for any
+    // quiescent start, and inv_bt is zero for a level that is entirely land.
+    const Real estdt_adv = (inv_adv > zero) ? cfl / inv_adv                : bogus_large_value;
+    const Real estdt_bt  = (inv_bt  > zero) ? cfl * Real(ndtfast) / inv_bt : bogus_large_value;
+
+    const Real estdt_lowM = amrex::min(estdt_adv, estdt_bt);
 
     if (verbose) {
-        if (fixed_dt <= zero) {
-            amrex::Print() << "Using cfl = " << cfl << std::endl;
-            if (estdt_lowM_inv > zero) {
-                amrex::Print() << "Slow  dt at level " << level << ":  " << estdt_lowM << std::endl;
-            } else {
-                amrex::Print() << "Slow  dt at level " << level << ": undefined " << std::endl;
-            }
+        amrex::Print() << "Using cfl = " << cfl << std::endl;
+        if (inv_adv > zero) {
+            amrex::Print() << "  advective    limit at level " << level << ":  " << estdt_adv << std::endl;
+        } else {
+            amrex::Print() << "  advective    limit at level " << level << ":  none (velocity is zero)" << std::endl;
+        }
+        if (inv_bt > zero) {
+            amrex::Print() << "  gravity wave limit at level " << level << ":  " << estdt_bt
+                           << "  (ndtfast = " << ndtfast << ")" << std::endl;
+        } else {
+            amrex::Print() << "  gravity wave limit at level " << level << ":  none (no wet cell has a depth)" << std::endl;
         }
         if (fixed_dt > zero) {
-            amrex::Print() << "Based on cfl of one " << std::endl;
-            if (estdt_lowM_inv > zero) {
-                amrex::Print() << "Slow  dt at level " << level << " would be:  " << estdt_lowM/cfl << std::endl;
+            if (estdt_lowM < bogus_large_value) {
+                amrex::Print() << "Slow  dt at level " << level << " would be:  " << estdt_lowM << std::endl;
             } else {
                 amrex::Print() << "Slow  dt at level " << level << " would be undefined " << std::endl;
             }
             amrex::Print() << "Fixed dt at level " << level << "       is:  " << fixed_dt << std::endl;
+        } else {
+            amrex::Print() << "Slow  dt at level " << level << ":  " << estdt_lowM << std::endl;
         }
     }
 
     if (fixed_dt > zero) {
         return fixed_dt;
-    } else {
-        return estdt_lowM;
     }
+
+    // Water at rest still carries gravity waves, so estdt_bt is finite for any level with
+    // one wet cell of nonzero depth. Reaching here means there is no such cell; returning
+    // the sentinel would let ComputeDt clamp dt to stop_time - t_new[0] and run the whole
+    // simulation in a single step.
+    if (estdt_lowM >= bogus_large_value) {
+        amrex::Abort("REMORA::estTimeStep: cannot estimate a timestep at level " +
+                     std::to_string(level) + ". No wet cell (mskr > 0.5) has a nonzero "
+                     "depth, so neither the advective nor the gravity wave limit is "
+                     "defined. Check the bathymetry and the land mask, or set "
+                     "remora.fixed_dt");
+    }
+
+    return estdt_lowM;
 }

--- a/Source/TimeIntegration/REMORA_TimeStepML.cpp
+++ b/Source/TimeIntegration/REMORA_TimeStepML.cpp
@@ -102,33 +102,30 @@ REMORA::timeStepML (Real time, int /*iteration*/)
         }
     }
 
-    if (solverChoice.use_barotropic)
-    {
-        int nfast_counter=nfast + 1;
+    int nfast_counter=nfast + 1;
 
-        for (int my_iif = 0; my_iif < nfast_counter; my_iif++) {
-            //Compute fast timestep from dt[lev] and ratio
-            for (int lev=0; lev <= finest_level; lev++)
+    for (int my_iif = 0; my_iif < nfast_counter; my_iif++) {
+        //Compute fast timestep from dt[lev] and ratio
+        for (int lev=0; lev <= finest_level; lev++)
+        {
+            Real dtfast_lev=dt[lev]/Real(ndtfast);
+            advance_2d_onestep(lev, dt[lev], dtfast_lev, my_iif, nfast_counter);
+            // **************************************************************************************
+            // Register old and new coarse data if we are at a level less than the finest level
+            // **************************************************************************************
+            if (lev < finest_level)
             {
-                Real dtfast_lev=dt[lev]/Real(fixed_ndtfast_ratio);
-                advance_2d_onestep(lev, dt[lev], dtfast_lev, my_iif, nfast_counter);
-                // **************************************************************************************
-                // Register old and new coarse data if we are at a level less than the finest level
-                // **************************************************************************************
-                if (lev < finest_level)
-                {
-                    if (cf_width >= 0) {
-                        // We must fill the ghost cells of these so that the parallel copy works correctly
-                        vec_ubar[lev]->FillBoundary(geom[lev].periodicity());
-                        FPr_ubar[lev].RegisterCoarseData({vec_ubar[lev].get(), vec_ubar[lev].get()}, {time, time + dt[lev]});
+                if (cf_width >= 0) {
+                    // We must fill the ghost cells of these so that the parallel copy works correctly
+                    vec_ubar[lev]->FillBoundary(geom[lev].periodicity());
+                    FPr_ubar[lev].RegisterCoarseData({vec_ubar[lev].get(), vec_ubar[lev].get()}, {time, time + dt[lev]});
 
-                        vec_vbar[lev]->FillBoundary(geom[lev].periodicity());
-                        FPr_vbar[lev].RegisterCoarseData({vec_vbar[lev].get(), vec_vbar[lev].get()}, {time, time + dt[lev]});
-                    }
+                    vec_vbar[lev]->FillBoundary(geom[lev].periodicity());
+                    FPr_vbar[lev].RegisterCoarseData({vec_vbar[lev].get(), vec_vbar[lev].get()}, {time, time + dt[lev]});
                 }
-            } // my_iif
+            }
         } // lev
-    } // use_barotropic
+    } // my_iif
 
     for (int lev=0; lev <= finest_level; lev++) {
         advance_3d_ml(lev, dt[lev]);

--- a/Source/TimeIntegration/REMORA_set_weights.cpp
+++ b/Source/TimeIntegration/REMORA_set_weights.cpp
@@ -13,8 +13,7 @@ void REMORA::set_weights (int /*lev*/) {
     Real gamma, scale;
     Real wsum, shift, cff;
 
-    //HACK should possibly store fixed_ndtfast elsewhere
-    int ndtfast=fixed_ndtfast_ratio>0 ? fixed_ndtfast_ratio : static_cast<int>(fixed_fast_dt / fixed_dt);
+    // ndtfast is the REMORA member, guaranteed positive by ReadParameters.
 
     //From mod_scalars
     Real Falpha = two;

--- a/Tests/test_files/Advection/Advection.i
+++ b/Tests/test_files/Advection/Advection.i
@@ -17,9 +17,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between computing mass

--- a/Tests/test_files/Advection/Advection.i
+++ b/Tests/test_files/Advection/Advection.i
@@ -17,7 +17,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between computing mass

--- a/Tests/test_files/Advection_ML/Advection_ML.i
+++ b/Tests/test_files/Advection_ML/Advection_ML.i
@@ -16,7 +16,7 @@ remora.is_periodic = 1 1 0
 
 # TIME STEP CONTROL
 remora.fixed_dt       = 100.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio  = 10 # Baratropic timestep size (seconds)
+remora.ndtfast  = 10
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 10       # timesteps between computing mass
@@ -43,7 +43,6 @@ remora.expand_plotvars_to_unif_rr = 1
 
 # SOLVER CHOICE
 remora.use_coriolis = false
-remora.use_barotropic=true
 remora.tracer_horizontal_advection_scheme = "centered4" # upstream3 or centered4
 
 # Linear EOS parameters

--- a/Tests/test_files/BC_inflow_no_value/BC_inflow_no_value.i
+++ b/Tests/test_files/BC_inflow_no_value/BC_inflow_no_value.i
@@ -33,7 +33,7 @@ remora.bc.xlo.velocity = 0. 0. 0.
 # TIME STEP CONTROL
 remora.fixed_dt       = 3600.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 20
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Tests/test_files/BC_per_variable/BC_per_side.i
+++ b/Tests/test_files/BC_per_variable/BC_per_side.i
@@ -47,7 +47,7 @@ remora.bc.ylo.velocity = 0.1 0. 0.
 # TIME STEP CONTROL
 remora.fixed_dt       = 3600.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 20
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Tests/test_files/BC_per_variable/BC_per_variable.i
+++ b/Tests/test_files/BC_per_variable/BC_per_variable.i
@@ -57,7 +57,7 @@ remora.bc.w.velocity    = 0.1 0. 0.
 # TIME STEP CONTROL
 remora.fixed_dt       = 3600.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 20
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Tests/test_files/BoundaryLayer/BoundaryLayer.i
+++ b/Tests/test_files/BoundaryLayer/BoundaryLayer.i
@@ -25,10 +25,9 @@ remora.bc.vbar.type   =  slipwall         periodic          outflow           pe
 remora.bc.zeta.type   =  slipwall         periodic          outflow           periodic
 remora.bc.tke.type    =  slipwall         periodic          outflow           periodic
 
-
 # TIME STEP CONTROL
 remora.fixed_dt       = 50.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 30
+remora.ndtfast = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Tests/test_files/Channel_Test/Channel_Test.i
+++ b/Tests/test_files/Channel_Test/Channel_Test.i
@@ -19,7 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 400.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 10
+remora.ndtfast = 10
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
@@ -61,7 +61,6 @@ remora.Zos = 0.002
 remora.Akk_bak = 5.0e-6
 remora.Akp_bak = 5.0e-6
 remora.Akv_bak = 1.0e-5
-
 
 # Linear EOS parameters
 remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State

--- a/Tests/test_files/Channel_Test_hires/Channel_Test_hires.i
+++ b/Tests/test_files/Channel_Test_hires/Channel_Test_hires.i
@@ -19,7 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 400.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 10
+remora.ndtfast = 10
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
@@ -62,7 +62,6 @@ remora.Akk_bak = 5.0e-6
 remora.Akp_bak = 5.0e-6
 remora.Akv_bak = 1.0e-5
 
-
 # Linear EOS parameters
 remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State
 remora.S0    = 15.0    # background salinity (nondimensional) constant
@@ -78,7 +77,6 @@ remora.use_coriolis = true
 remora.coriolis_type = beta_plane
 remora.coriolis_f0 = 1.0e-4
 remora.coriolis_beta = 0.0
-
 
 # HIGH-RESOLUTION BATHYMETRY -- transparency check
 # ChannelTest sets h = 50 everywhere with setVal, covering every grow cell and both

--- a/Tests/test_files/DogboneAnalytic/DogboneAnalytic.i
+++ b/Tests/test_files/DogboneAnalytic/DogboneAnalytic.i
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Tests/test_files/DogboneAnalytic/DogboneAnalytic.i
+++ b/Tests/test_files/DogboneAnalytic/DogboneAnalytic.i
@@ -18,7 +18,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 6.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0

--- a/Tests/test_files/DogboneAnalytic_MLhires/DogboneAnalytic_MLhires.i
+++ b/Tests/test_files/DogboneAnalytic_MLhires/DogboneAnalytic_MLhires.i
@@ -24,7 +24,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Tests/test_files/DogboneAnalytic_MLhires/DogboneAnalytic_MLhires.i
+++ b/Tests/test_files/DogboneAnalytic_MLhires/DogboneAnalytic_MLhires.i
@@ -24,7 +24,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Tests/test_files/DogboneAnalytic_MLquad/DogboneAnalytic_MLquad.i
+++ b/Tests/test_files/DogboneAnalytic_MLquad/DogboneAnalytic_MLquad.i
@@ -22,7 +22,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Tests/test_files/DogboneAnalytic_MLquad/DogboneAnalytic_MLquad.i
+++ b/Tests/test_files/DogboneAnalytic_MLquad/DogboneAnalytic_MLquad.i
@@ -22,7 +22,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Tests/test_files/DogboneAnalytic_MLvel/DogboneAnalytic_MLvel.i
+++ b/Tests/test_files/DogboneAnalytic_MLvel/DogboneAnalytic_MLvel.i
@@ -24,7 +24,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.ndtfast = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Tests/test_files/DogboneAnalytic_MLvel/DogboneAnalytic_MLvel.i
+++ b/Tests/test_files/DogboneAnalytic_MLvel/DogboneAnalytic_MLvel.i
@@ -24,7 +24,7 @@ remora.bc.yhi.type = "slipwall"
 
 # TIME STEP CONTROL
 remora.fixed_dt            = 2.0 # Timestep size (seconds)
-remora.fixed_ndtfast_ratio = 20 # Baratropic timestep size (seconds)
+remora.ndtfast = 20 # Baratropic timestep size (seconds)
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed

--- a/Tests/test_files/DoubleGyre/DoubleGyre.i
+++ b/Tests/test_files/DoubleGyre/DoubleGyre.i
@@ -22,9 +22,9 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 3600.0 # Timestep size (seconds)
 
-remora.fixed_ndtfast_ratio = 20
+remora.ndtfast = 20
 
-#remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+#remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
@@ -64,7 +64,6 @@ remora.visc2 = 1280.0
 remora.tnu2_salt = 1280.0
 remora.tnu2_temp = 1280.0
 remora.tnu2_scalar = 1280.0
-
 
 # Linear EOS parameters
 remora.R0    = 1028.0  # background density value (Kg/m3) used in Linear Equation of State

--- a/Tests/test_files/DoublyPeriodic/DoublyPeriodic.i
+++ b/Tests/test_files/DoublyPeriodic/DoublyPeriodic.i
@@ -17,7 +17,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/DoublyPeriodic/DoublyPeriodic.i
+++ b/Tests/test_files/DoublyPeriodic/DoublyPeriodic.i
@@ -17,9 +17,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 30 # Baratropic timestep size (seconds)
+remora.ndtfast  = 30 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount/Seamount.i
+++ b/Tests/test_files/Seamount/Seamount.i
@@ -18,9 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount/Seamount.i
+++ b/Tests/test_files/Seamount/Seamount.i
@@ -18,7 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires/Seamount_hires.i
+++ b/Tests/test_files/Seamount_hires/Seamount_hires.i
@@ -18,9 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires/Seamount_hires.i
+++ b/Tests/test_files/Seamount_hires/Seamount_hires.i
@@ -18,7 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_grid_max_abort/Seamount_hires_grid_max_abort.i
+++ b/Tests/test_files/Seamount_hires_grid_max_abort/Seamount_hires_grid_max_abort.i
@@ -18,9 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_grid_max_abort/Seamount_hires_grid_max_abort.i
+++ b/Tests/test_files/Seamount_hires_grid_max_abort/Seamount_hires_grid_max_abort.i
@@ -18,7 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_grid_zero_abort/Seamount_hires_grid_zero_abort.i
+++ b/Tests/test_files/Seamount_hires_grid_zero_abort/Seamount_hires_grid_zero_abort.i
@@ -18,9 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_grid_zero_abort/Seamount_hires_grid_zero_abort.i
+++ b/Tests/test_files/Seamount_hires_grid_zero_abort/Seamount_hires_grid_zero_abort.i
@@ -18,7 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_init_abort/Seamount_hires_init_abort.i
+++ b/Tests/test_files/Seamount_hires_init_abort/Seamount_hires_init_abort.i
@@ -18,9 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_init_abort/Seamount_hires_init_abort.i
+++ b/Tests/test_files/Seamount_hires_init_abort/Seamount_hires_init_abort.i
@@ -18,7 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_init_max_abort/Seamount_hires_init_max_abort.i
+++ b/Tests/test_files/Seamount_hires_init_max_abort/Seamount_hires_init_max_abort.i
@@ -18,9 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_init_max_abort/Seamount_hires_init_max_abort.i
+++ b/Tests/test_files/Seamount_hires_init_max_abort/Seamount_hires_init_max_abort.i
@@ -18,7 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_r4/Seamount_hires_r4.i
+++ b/Tests/test_files/Seamount_hires_r4/Seamount_hires_r4.i
@@ -18,9 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-#remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-# remora.fixed_fast_dt  = 300.0 # Baratropic timestep size (seconds) testing value
-remora.fixed_ndtfast_ratio  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20 # Baratropic timestep size (seconds)
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Seamount_hires_r4/Seamount_hires_r4.i
+++ b/Tests/test_files/Seamount_hires_r4/Seamount_hires_r4.i
@@ -18,7 +18,7 @@ remora.is_periodic = 1 1 0
 # TIME STEP CONTROL
 remora.fixed_dt       = 60.0 # Timestep size (seconds)
 # NDTFAST  = 30.0 # Number of baratropic steps => 300.0/30.0 = 10.0
-remora.ndtfast  = 20 # Baratropic timestep size (seconds)
+remora.ndtfast  = 20
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval   = 1       # timesteps between computing mass

--- a/Tests/test_files/Upwelling/Upwelling.i
+++ b/Tests/test_files/Upwelling/Upwelling.i
@@ -19,9 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Tests/test_files/Upwelling_Fennel/Upwelling_Fennel.i
+++ b/Tests/test_files/Upwelling_Fennel/Upwelling_Fennel.i
@@ -31,9 +31,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Tests/test_files/Upwelling_Fennel_hires_init/Upwelling_Fennel_hires_init.i
+++ b/Tests/test_files/Upwelling_Fennel_hires_init/Upwelling_Fennel_hires_init.i
@@ -26,9 +26,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Tests/test_files/Upwelling_GLS/Upwelling_GLS.i
+++ b/Tests/test_files/Upwelling_GLS/Upwelling_GLS.i
@@ -19,9 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Tests/test_files/Upwelling_NLEOS/Upwelling_NLEOS.i
+++ b/Tests/test_files/Upwelling_NLEOS/Upwelling_NLEOS.i
@@ -19,9 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Tests/test_files/Upwelling_logdrag/Upwelling_logdrag.i
+++ b/Tests/test_files/Upwelling_logdrag/Upwelling_logdrag.i
@@ -19,9 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass

--- a/Tests/test_files/Upwelling_qdrag/Upwelling_qdrag.i
+++ b/Tests/test_files/Upwelling_qdrag/Upwelling_qdrag.i
@@ -19,9 +19,7 @@ remora.bc.yhi.type = "SlipWall"
 # TIME STEP CONTROL
 remora.fixed_dt       = 300.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
-
-remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
+remora.ndtfast  = 30 # Ratio of baroclinic to barotropic time step
 
 # DIAGNOSTICS & VERBOSITY
 remora.sum_interval  = 1       # timesteps between computing mass


### PR DESCRIPTION
## Summary

Fixes #602: `estTimeStep` limited `dt` by advective velocity alone, so a run started
from rest returned a sentinel and took the entire simulation in one step. The estimate
now includes the free-surface gravity wave speed and uses the per-cell metric terms
`pm`/`pn` instead of the geometry's uniform cell size.

While in the same code, three timestep inputs are cleaned up: `remora.use_barotropic`
and `remora.fixed_fast_dt` are removed, and `remora.fixed_ndtfast_ratio` becomes
`remora.ndtfast`.

**This changes the inputs interface. See [Backwards compatibility](#backwards-compatibility).**

## Problem

`estTimeStep` reduced over cell-centered velocity only:

```cpp
new_lm_dt = amrex::max(|u|*dxinv[0], |v|*dxinv[1], |w|*dxinv[2], new_lm_dt);
...
if (estdt_lowM_inv > zero) estdt_lowM = cfl / estdt_lowM_inv;
```

On a quiescent start — `u = v = w = 0`, the standard spinup IC — the reduction is zero
and `estdt_lowM` keeps its `bogus_large_value` sentinel (1e150). `ComputeDt`'s
`change_max` cap is inert on the first call, because `dt[]` is itself seeded to
`bogus_large_value`, so the sentinel reached `dt[0]` intact when `stop_time` was unset,
or was laundered into `stop_time - t_new[0]` when it was set. Confirmed on Upwelling:
`DT = 1e+150` and NaN after one step, no warning.

Two things were wrong. The gravity wave speed never entered the estimate, even though
`Inputs.rst` advertised `dt = cfl*dx/(u+c)`. And `dxinv` is the nominal domain-uniform
spacing, not the real cell size — REMORA already carries true per-cell metrics in
`vec_pm`/`vec_pn`. This was the last physics use of `geom.InvCellSizeArray()` in
`Source/`.

## Changes

### The estimate

`dt` is now the smaller of two limits, each a max over the wet cells of the level:

```
dt_adv  = cfl / max( |u|*pm, |v|*pn, |w|/Hz )
dt_grav = cfl * ndtfast / max( sqrt(g*|h|) * sqrt(pm^2 + pn^2) )
dt      = min(dt_adv, dt_grav)
```

`dt_grav` is the Courant quantity ROMS forms as `Cg_max` in `metrics.F`. Because REMORA
is mode-split, the barotropic constraint is applied to the *fast* step and multiplied
back up by `ndtfast`, rather than imposed on the slow step directly — the latter would
be roughly `ndtfast` times stricter than necessary.

Also in `estTimeStep`:

- Land (`mskr <= 0.5`) is skipped, matching how ROMS forms `Cg_max` over water points;
  `h` there is a fill depth, not a real one.
- The vertical term uses the true layer thickness `Hz` rather than the uniform `dz`,
  which is the thickness of a sigma level and not of a cell.
- The reduction needs six FabArrays (`ccvel`, `Hz`, `h`, `pm`, `pn`, `mskr`) and
  `amrex::ReduceMax`'s FabArray overloads take at most three, so it is driven through
  `ReduceOps`/`ReduceData` directly. Unlike `amrex::ReduceMax`, `ReduceOps::eval` has no
  host fallback in a GPU build, so no `LaunchSafeGuard` is needed.
- On the CFL path, `estTimeStep` aborts when neither limit is defined instead of handing
  `ComputeDt` the sentinel. `ComputeDt` asserts `dt_0` is positive, finite, and below
  `bogus_large_value` — that last clause is the load-bearing one, since `stop_time`
  defaults to `Real::max` and the sentinel is otherwise a perfectly finite number.

### Inputs

`remora.use_barotropic` is removed. The barotropic mode is always on — the `false`
branch was debug-only, and the fast step it skipped is exactly what the mode-split
estimate above assumes exists.

`remora.fixed_fast_dt` is removed. It only ever served to infer the substep count, and
only when `remora.fixed_dt` was also given, which left the ratio at zero on every other
path — including any CFL-driven run, where `dt` is not known until run time. This also
retires the inverted fallback in `set_weights` (`fixed_fast_dt / fixed_dt`).

`remora.fixed_ndtfast_ratio` becomes `remora.ndtfast`, with the old name kept as a
deprecated alias. `ndtfast` is now required to be positive at parse time; previously a
CFL run left it at 0 and `Advance.cpp` divided by it.

## Backwards compatibility

| Old | New |
|---|---|
| `remora.fixed_ndtfast_ratio = N` | `remora.ndtfast = N` — old name still works, warns |
| `remora.fixed_fast_dt = X` | `remora.ndtfast = fixed_dt / X` — hard error |
| `remora.use_barotropic = true` | delete the line — hard error |
| `remora.use_barotropic = false` | no longer supported — hard error |

`amrex.abort_on_unused_inputs` is off by default, so silently dropping these names would
have let a stale `use_barotropic = false` run different physics than the input file asks
for. Both removed names therefore abort on *presence*, which means an input setting
`use_barotropic = true` — a harmless no-op — also has to be edited. That is stricter
than strictly necessary; happy to soften it to false-only if reviewers prefer.

Both checks use `ParmParse::contains` rather than `query`, so the schema scraper behind
`Exec/Generic` does not re-advertise a parameter that no longer exists.

All 63 input files under `Exec/` and `Tests/test_files/` are converted.
`Exec/Upwelling` and `Exec/Upwelling_Coupling` relied on `fixed_fast_dt` inference and
now state `remora.ndtfast = 30` outright — the value that was being inferred. A stale
`# Baratropic timestep size (seconds)` comment, copy-pasted from the removed
`fixed_fast_dt` lines onto `ndtfast`, is dropped from 37 files; it described the wrong
quantity and the wrong units.

`Exec/Generic/inputs_generic` and `remora_value_hints.json` are regenerated. Gold-file
`job_info` records are left alone — they are snapshots of the runs that produced the
reference data, not inputs.

## Tests

All 29 regression tests pass with **unchanged answers**. Every input under `Exec/` and
`Tests/test_files/` sets `fixed_dt`, so `estTimeStep` returns `fixed_dt` there and the
CFL path is not exercised by ctest at all — a green suite proves the fixed-dt path is
untouched, not that the new estimate is right. Hence the manual verification below.

## Verification

**The bug itself.** Upwelling with `fixed_dt` commented out, `remora.cfl = 0.8`,
`remora.ndtfast = 30`:

- before: `Slow dt at level 0: undefined`, then `DT = 1e+150` and NaN after one step
- after: `dt = 442.4765676 s`, run advances normally

**Metrics are actually used.** `Exec/BoundaryLayer` is the only case with
`grid_scale_type = analytic`, so `pm` varies (dx 725 m → 2625 m against a nominal
2564 m). It reports `dt = 1390.298869 s`, matching an independent calculation from the
analytic `dx(i)` and `h(x)` to all printed digits. On a uniform grid the metric and
`dxinv` answers agree, as they must — `pm` is `setVal(dxi[0])` there.

**Guards.** Each aborts with its intended message: `fixed_fast_dt` present,
`use_barotropic` present, `ndtfast <= 0`, and both `ndtfast` and `fixed_ndtfast_ratio`
set at once. The deprecated alias alone warns and runs.

**Masking.** `Exec/DogboneAnalytic/inputs_orlanski_mask` (which has real `mskr = 0`
cells) gives a finite, sensible `dt` under CFL.

## Notes for the reviewer

The estimate does **not** include the internal gravity wave speed, so a large
`remora.ndtfast` can still yield a baroclinic step that under-resolves the internal
modes. Adding it needs N² and is real scope; it is documented in `Inputs.rst` instead.

`set_weights` previously fell back to `static_cast<int>(fixed_fast_dt / fixed_dt)` — an
inverted ratio. That expression is gone with `fixed_fast_dt`, but it is worth knowing it
was there, since it silently produced `ndtfast = 0` on the paths that reached it.

If you re-run ctest locally after editing an input: CMake copies `Tests/test_files/**`
into `Build/` at configure time, so re-run `cmake -S . -B Build` first or ctest will use
the stale copy.
