### PR TITLE
Cover the barotropic substep count with regression tests (#599)

### DIFF
--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -349,6 +349,33 @@ add_test_equiv(BC_per_variable BC_per_side "remora_exec" "plt00010" "plt_side000
 add_test_abort(BC_inflow_no_value "remora_exec" "needs an inflow value")
 
 #=============================================================================
+# Barotropic substep count
+#
+# remora.ndtfast is the number of barotropic steps per baroclinic step. Advance and
+# timeStepML form the fast step as dt / ndtfast and set_weights sizes the barotropic filter
+# with it, none of which is guarded at the point of use, so it has to be positive by the time
+# parsing finishes. It has no usable default: it was once inferred from remora.fixed_dt /
+# remora.fixed_fast_dt, which left it at zero on every path that did not set both -- a
+# CFL-driven run cannot set them, since dt is not known until run time. Zero divides by zero
+# and sizes the weight vectors to one element, which advance_2d then reads past the end of;
+# amrex::Vector does not bounds-check that. So the unset case must abort, and does.
+#
+# The other three lanes cover the input names around it. fixed_fast_dt is gone and must be
+# rejected rather than ignored: amrex does not abort on unused inputs, so a stale input file
+# naming it would otherwise run with whatever substep count it did not ask for. The
+# fixed_ndtfast_ratio alias must still deliver the count it names -- agreement here cannot
+# pass for the wrong reason, because a run that ignored the alias would be left at zero and
+# abort rather than agree -- and naming the count under both spellings at once is an error,
+# since silently preferring one leaves the input file reading as though it asked for the other.
+#=============================================================================
+
+add_test_equiv(Channel_Test_ndtfast_alias Channel_Test_ndtfast_named "remora_exec" "plt00010" "plt_named00010")
+
+add_test_abort(Channel_Test_ndtfast_unset_abort  "remora_exec" "remora.ndtfast must be a positive integer")
+add_test_abort(Channel_Test_fixed_fast_dt_abort  "remora_exec" "remora.fixed_fast_dt has been removed")
+add_test_abort(Channel_Test_ndtfast_both_abort   "remora_exec" "and remora.fixed_ndtfast_ratio are both")
+
+#=============================================================================
 # Performance tests
 #=============================================================================
 

--- a/Tests/test_files/Channel_Test_fixed_fast_dt_abort/Channel_Test_fixed_fast_dt_abort.i
+++ b/Tests/test_files/Channel_Test_fixed_fast_dt_abort/Channel_Test_fixed_fast_dt_abort.i
@@ -1,0 +1,83 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+remora.prob_name = ChannelTest
+
+remora.max_step = 0
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -50.
+remora.prob_hi     = 100000. 300000.       0.
+
+remora.n_cell           =  20     60      50
+
+remora.is_periodic = 1 0 0
+
+remora.bc.ylo.type = "SlipWall"
+remora.bc.yhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+# remora.fixed_fast_dt has been removed; it used to be the way the substep count was
+# inferred. amrex ignores unrecognized inputs by default, so this stands for the stale
+# input file that would otherwise run with a substep count it never asked for.
+remora.fixed_dt       = 400.0 # Timestep size (seconds)
+remora.fixed_fast_dt  = 40.0  # Removed: no longer a REMORA input
+remora.ndtfast = 10
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt        # prefix of plotfile name
+remora.plot_int      = -1         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+remora.vertical_mixing_type = gls
+
+remora.gls_P = 3.0
+remora.gls_M = 1.5
+remora.gls_N = -1.0
+remora.gls_Kmin = 7.6e-6
+remora.gls_Pmin = 1.0e-12
+
+remora.gls_cmu0 = 0.5477
+remora.gls_c1 = 1.44
+remora.gls_c2 = 1.92
+remora.gls_c3m = -0.4
+remora.gls_c3p = 1.0
+remora.gls_sigk = 1.0
+remora.gls_sigp = 1.3
+
+remora.Zob = 0.002
+remora.Zos = 0.002
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0e-5
+
+# Linear EOS parameters
+remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 15.0    # background salinity (nondimensional) constant
+remora.T0    = 10.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.7e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+remora.tcline = 25.0
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 1.0e-4
+remora.coriolis_beta = 0.0
+

--- a/Tests/test_files/Channel_Test_ndtfast_alias/Channel_Test_ndtfast_alias.i
+++ b/Tests/test_files/Channel_Test_ndtfast_alias/Channel_Test_ndtfast_alias.i
@@ -1,0 +1,81 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+remora.prob_name = ChannelTest
+
+remora.max_step = 10
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -50.
+remora.prob_hi     = 100000. 300000.       0.
+
+remora.n_cell           =  20     60      50
+
+remora.is_periodic = 1 0 0
+
+remora.bc.ylo.type = "SlipWall"
+remora.bc.yhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+# States the substep count under the deprecated name. Paired with
+# Channel_Test_ndtfast_named.i, which states the same count under the current name.
+remora.fixed_dt       = 400.0 # Timestep size (seconds)
+remora.fixed_ndtfast_ratio = 10
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt        # prefix of plotfile name
+remora.plot_int      = 10         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+remora.vertical_mixing_type = gls
+
+remora.gls_P = 3.0
+remora.gls_M = 1.5
+remora.gls_N = -1.0
+remora.gls_Kmin = 7.6e-6
+remora.gls_Pmin = 1.0e-12
+
+remora.gls_cmu0 = 0.5477
+remora.gls_c1 = 1.44
+remora.gls_c2 = 1.92
+remora.gls_c3m = -0.4
+remora.gls_c3p = 1.0
+remora.gls_sigk = 1.0
+remora.gls_sigp = 1.3
+
+remora.Zob = 0.002
+remora.Zos = 0.002
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0e-5
+
+# Linear EOS parameters
+remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 15.0    # background salinity (nondimensional) constant
+remora.T0    = 10.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.7e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+remora.tcline = 25.0
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 1.0e-4
+remora.coriolis_beta = 0.0
+

--- a/Tests/test_files/Channel_Test_ndtfast_alias/Channel_Test_ndtfast_named.i
+++ b/Tests/test_files/Channel_Test_ndtfast_alias/Channel_Test_ndtfast_named.i
@@ -1,0 +1,80 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+remora.prob_name = ChannelTest
+
+remora.max_step = 10
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -50.
+remora.prob_hi     = 100000. 300000.       0.
+
+remora.n_cell           =  20     60      50
+
+remora.is_periodic = 1 0 0
+
+remora.bc.ylo.type = "SlipWall"
+remora.bc.yhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+# The current spelling of the substep count stated by Channel_Test_ndtfast_alias.i.
+remora.fixed_dt       = 400.0 # Timestep size (seconds)
+remora.ndtfast = 10
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt_named        # prefix of plotfile name
+remora.plot_int      = 10         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+remora.vertical_mixing_type = gls
+
+remora.gls_P = 3.0
+remora.gls_M = 1.5
+remora.gls_N = -1.0
+remora.gls_Kmin = 7.6e-6
+remora.gls_Pmin = 1.0e-12
+
+remora.gls_cmu0 = 0.5477
+remora.gls_c1 = 1.44
+remora.gls_c2 = 1.92
+remora.gls_c3m = -0.4
+remora.gls_c3p = 1.0
+remora.gls_sigk = 1.0
+remora.gls_sigp = 1.3
+
+remora.Zob = 0.002
+remora.Zos = 0.002
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0e-5
+
+# Linear EOS parameters
+remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 15.0    # background salinity (nondimensional) constant
+remora.T0    = 10.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.7e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+remora.tcline = 25.0
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 1.0e-4
+remora.coriolis_beta = 0.0
+

--- a/Tests/test_files/Channel_Test_ndtfast_both_abort/Channel_Test_ndtfast_both_abort.i
+++ b/Tests/test_files/Channel_Test_ndtfast_both_abort/Channel_Test_ndtfast_both_abort.i
@@ -1,0 +1,82 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+remora.prob_name = ChannelTest
+
+remora.max_step = 0
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -50.
+remora.prob_hi     = 100000. 300000.       0.
+
+remora.n_cell           =  20     60      50
+
+remora.is_periodic = 1 0 0
+
+remora.bc.ylo.type = "SlipWall"
+remora.bc.yhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+# The substep count is named twice, once by each spelling. Silently preferring one would
+# leave the input file reading as though it asked for the other, so this is an error.
+remora.fixed_dt       = 400.0 # Timestep size (seconds)
+remora.ndtfast = 10
+remora.fixed_ndtfast_ratio = 20
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt        # prefix of plotfile name
+remora.plot_int      = -1         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+remora.vertical_mixing_type = gls
+
+remora.gls_P = 3.0
+remora.gls_M = 1.5
+remora.gls_N = -1.0
+remora.gls_Kmin = 7.6e-6
+remora.gls_Pmin = 1.0e-12
+
+remora.gls_cmu0 = 0.5477
+remora.gls_c1 = 1.44
+remora.gls_c2 = 1.92
+remora.gls_c3m = -0.4
+remora.gls_c3p = 1.0
+remora.gls_sigk = 1.0
+remora.gls_sigp = 1.3
+
+remora.Zob = 0.002
+remora.Zos = 0.002
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0e-5
+
+# Linear EOS parameters
+remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 15.0    # background salinity (nondimensional) constant
+remora.T0    = 10.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.7e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+remora.tcline = 25.0
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 1.0e-4
+remora.coriolis_beta = 0.0
+

--- a/Tests/test_files/Channel_Test_ndtfast_unset_abort/Channel_Test_ndtfast_unset_abort.i
+++ b/Tests/test_files/Channel_Test_ndtfast_unset_abort/Channel_Test_ndtfast_unset_abort.i
@@ -1,0 +1,82 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+remora.prob_name = ChannelTest
+
+remora.max_step = 0
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =      0.      0.     -50.
+remora.prob_hi     = 100000. 300000.       0.
+
+remora.n_cell           =  20     60      50
+
+remora.is_periodic = 1 0 0
+
+remora.bc.ylo.type = "SlipWall"
+remora.bc.yhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+# remora.ndtfast is deliberately left unset. There is then no number of barotropic
+# substeps to step with, so the run must stop at parse time rather than proceed with
+# ndtfast = 0 -- which divides by zero forming the fast step and sizes the barotropic
+# weight vectors to a single element that advance_2d then indexes past.
+remora.fixed_dt       = 400.0 # Timestep size (seconds)
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1       # timesteps between integrated/max quantities, if remora.v > 0
+remora.v             = 0       # verbosity in REMORA.cpp (0: none, 1: integrated quantities, etc, 2: print boxes)
+amr.v                = 1       # verbosity in Amr.cpp
+
+# CHECKPOINT FILES
+remora.check_file      = chk        # root name of checkpoint file
+remora.check_int       = -57600      # number of timesteps between checkpoints
+
+# PLOTFILES
+remora.plot_file     = plt        # prefix of plotfile name
+remora.plot_int      = -1         # number of timesteps between plotfiles
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+remora.vertical_mixing_type = gls
+
+remora.gls_P = 3.0
+remora.gls_M = 1.5
+remora.gls_N = -1.0
+remora.gls_Kmin = 7.6e-6
+remora.gls_Pmin = 1.0e-12
+
+remora.gls_cmu0 = 0.5477
+remora.gls_c1 = 1.44
+remora.gls_c2 = 1.92
+remora.gls_c3m = -0.4
+remora.gls_c3p = 1.0
+remora.gls_sigk = 1.0
+remora.gls_sigp = 1.3
+
+remora.Zob = 0.002
+remora.Zos = 0.002
+
+# turbulence closure parameters
+remora.Akk_bak = 5.0e-6
+remora.Akp_bak = 5.0e-6
+remora.Akv_bak = 1.0e-5
+
+# Linear EOS parameters
+remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State
+remora.S0    = 15.0    # background salinity (nondimensional) constant
+remora.T0    = 10.0    # background potential temperature (Celsius) constant
+remora.Tcoef = 1.7e-4  # linear equation of state parameter (1/Celsius)
+remora.Scoef = 7.6e-4     # linear equation of state parameter (nondimensional)
+remora.rho0  = 1025.0  # Mean density (Kg/m3) used when Boussinesq approx is inferred
+
+remora.tcline = 25.0
+
+# Coriolis params
+remora.use_coriolis = true
+remora.coriolis_type = beta_plane
+remora.coriolis_f0 = 1.0e-4
+remora.coriolis_beta = 0.0
+


### PR DESCRIPTION
Issue 599 reported the substep count being derived at two sites that had drifted apart: ReadParameters truncated fixed_dt / fixed_fast_dt and compared it to the integer exactly, while set_weights had the fallback inverted and so produced ndtfast = 0 on every path that did not set both time steps -- a division by zero and an out-of-bounds read of the barotropic weight vectors, which amrex::Vector does not bounds-check.

Both defects are already fixed: fc6b5a2 removed fixed_fast_dt outright, so there is no derivation left to get wrong, and made a positive ndtfast a parse-time requirement on every path, the CFL-driven one included. That commit records the behavior as verified by hand, and nothing in the suite holds it. These tests do.

Channel_Test_ndtfast_unset_abort leaves the count unset and pins the abort, which is the F066 path. Channel_Test_fixed_fast_dt_abort names the removed input and pins that it is rejected rather than ignored, since amrex does not abort on unused inputs. Channel_Test_ndtfast_alias pins that the deprecated fixed_ndtfast_ratio spelling still delivers the count it names, by agreeing with the same run under the current spelling -- agreement cannot pass for the wrong reason here, because a run that ignored the alias would be left at zero and abort rather than agree. Channel_Test_ndtfast_both_abort pins that naming the count under both spellings is an error.

Each guard was disabled in turn to confirm the tests are discriminating: removing the ndtfast <= 0 abort, the fixed_fast_dt rejection, or the both-names abort fails exactly the corresponding test. Removing the whole alias block fails the alias test and the both-names test together, since the latter's check is nested inside it. All 31 tests pass unmutated; no source file is touched.