### PR TITLE
Fix CUDA configure after AMReX removed set_cuda_architectures

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - cuda_ver: "12.6"
             cuda_pkg: 12-6
-            cuda_arch: "8.0"
+            cuda_arch: "80"
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.13.1
@@ -60,7 +60,7 @@ jobs:
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
             -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON \
-            -DAMReX_CUDA_ARCH=${{matrix.cuda_arch}} \
+            -DCMAKE_CUDA_ARCHITECTURES=${{matrix.cuda_arch}} \
             -DREMORA_DIM:STRING=3 \
             -DREMORA_ENABLE_MPI:BOOL=OFF \
             -DREMORA_ENABLE_CUDA:BOOL=ON .

--- a/CMake/SetREMORACompileFlags.cmake
+++ b/CMake/SetREMORACompileFlags.cmake
@@ -33,13 +33,16 @@ if(REMORA_ENABLE_CUDA)
   endif()
   separate_arguments(REMORA_CUDA_FLAGS)
   target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${REMORA_CUDA_FLAGS}>)
-  # Add arch flags to both compile and linker to avoid warnings about missing arch
-  set(CMAKE_CUDA_FLAGS ${NVCC_ARCH_FLAGS})
-  set_cuda_architectures(AMReX_CUDA_ARCH)
-  set_target_properties( ${target}
-     PROPERTIES
-     CUDA_ARCHITECTURES "${AMREX_CUDA_ARCHS}"
-     )
+  # AMReX resolves the CUDA architectures itself (Tools/CMake/AMReXCUDAArchs.cmake) into
+  # CMAKE_CUDA_ARCHITECTURES and exports the result as AMREX_CUDA_ARCHS. Build this target
+  # for the same architectures as AMReX; if AMReX did not export them, the target inherits
+  # CMAKE_CUDA_ARCHITECTURES.
+  if(AMREX_CUDA_ARCHS)
+    set_target_properties( ${target}
+       PROPERTIES
+       CUDA_ARCHITECTURES "${AMREX_CUDA_ARCHS}"
+       )
+  endif()
   set_target_properties(
     ${target} PROPERTIES
     LANGUAGE CUDA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if(REMORA_ENABLE_CUDA)
         message(WARNING
           "Your CMAKE_CUDA_ARCHITECTURES value is ${CMAKE_CUDA_ARCHITECTURES}, which includes "
           "unsupported architecture ${_arch}."
-          "Please use AMReX_CUDA_ARCH 6.0 or newer.")
+          "Please use CMAKE_CUDA_ARCHITECTURES 60 or newer.")
         break()
       endif()
     endforeach()


### PR DESCRIPTION
AMReX's CUDA-architecture rework replaced the set_cuda_architectures() helper (formerly in Tools/CMake/AMReXUtils.cmake) with Tools/CMake/AMReXCUDAArchs.cmake, which resolves the architectures into the standard CMAKE_CUDA_ARCHITECTURES cache variable before enable_language(CUDA). REMORA picked that helper up via CMAKE_MODULE_PATH, so once the AMReX submodule was bumped past the rework (7181df4, pin f2cbba4) every CUDA configure failed with

  CMake Error at CMake/SetREMORACompileFlags.cmake:38
  (set_cuda_architectures): Unknown CMake command
  "set_cuda_architectures".

Drop the call. AMReX still exports the architectures it was built for as AMREX_CUDA_ARCHS (AMReXCUDAOptions.cmake for the submodule build, AMReXConfig.cmake.in for an external install), so the target keeps being built for the same set; guard it so a build against an AMReX that does not export them inherits CMAKE_CUDA_ARCHITECTURES instead of getting an empty property. Also drop the adjacent set(CMAKE_CUDA_FLAGS ${NVCC_ARCH_FLAGS}), which was dead: NVCC_ARCH_FLAGS is never defined and a plain set() inside a function is function-scoped.

Switch cuda-ci.yml to -DCMAKE_CUDA_ARCHITECTURES=80; AMReX_CUDA_ARCH still works but is deprecated and warns, and the modern interface wants the integer form. Update the unsupported-architecture warning in CMakeLists.txt to name the option that is now in use.