### PR TITLE
record which forcing inputs deck named, let withheld ones fall back

### DIFF
--- a/Exec/Generic/inputs_generic
+++ b/Exec/Generic/inputs_generic
@@ -70,15 +70,15 @@ remora.Zob = 0.002
 # type=Real; method=queryAdd
 remora.Zos = 0.002
 
-# Outputs forcing variables if true
+# Constant humidity [fraction or kg/kg]
 # type=Real; method=queryAdd
 remora.air_humidity = 0.776
 
-# Outputs forcing variables if true
+# knowable; see bulk_flux_value_specified. Legacy aliases (lwrad, eminusp_value) feed the same lane, so they count too.
 # type=Real; method=queryAdd
 remora.air_pressure = 1013.48
 
-# Outputs forcing variables if true
+# eminusp_value) feed the same lane, so they count too.
 # type=Real; method=queryAdd
 remora.air_temperature = 23.567
 
@@ -102,19 +102,19 @@ remora.bdy_time_varname = <UNKNOWN_DEFAULT>
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_u_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1944
+# source: Source/REMORA.cpp:1943
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_ubar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1943
+# source: Source/REMORA.cpp:1942
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_v_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1945
+# source: Source/REMORA.cpp:1944
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_vbar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1946
+# source: Source/REMORA.cpp:1945
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_zeta_time_varname = <UNKNOWN_DEFAULT>
 
@@ -170,19 +170,19 @@ remora.cfl = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.change_max = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1742
+# source: Source/REMORA.cpp:1741
 # type=string; method=queryAdd
 remora.check_file = chk
 
-# source: Source/REMORA.cpp:1743
+# source: Source/REMORA.cpp:1742
 # type=int; method=queryAdd
 remora.check_int = -57600
 
-# source: Source/REMORA.cpp:1744
+# source: Source/REMORA.cpp:1743
 # type=Real; method=queryAdd
 remora.check_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1849
+# source: Source/REMORA.cpp:1848
 # type=bool; method=queryAdd
 remora.chunk_history_file = <UNKNOWN_DEFAULT>
 
@@ -222,7 +222,7 @@ remora.coriolis_type = beta_plane
 # type=string; method=queryAdd
 remora.coupling_type = TwoWay
 
-# source: Source/REMORA.cpp:1761
+# source: Source/REMORA.cpp:1760
 # type=Vector<std::string>; method=queryarr
 remora.data_log = <UNKNOWN_DEFAULT>
 
@@ -250,7 +250,7 @@ remora.do_rivers_scalar = <UNKNOWN_DEFAULT>
 # type=bool; method=queryAdd
 remora.do_rivers_temp = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:274
+# source: Source/REMORA_DataStruct.H:280
 # type=bool; method=queryAdd
 remora.eminusp = true
 
@@ -258,7 +258,7 @@ remora.eminusp = true
 # type=bool; method=queryAdd
 remora.eminusp_correct_ssh = true
 
-# source: Source/REMORA_DataStruct.H:270
+# source: Source/REMORA_DataStruct.H:276
 # type=Real; method=query
 remora.eminusp_value = <UNKNOWN_DEFAULT>
 
@@ -266,7 +266,7 @@ remora.eminusp_value = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.eos_type = linear
 
-# source: Source/REMORA.cpp:1745
+# source: Source/REMORA.cpp:1744
 # type=bool; method=queryAdd
 remora.expand_plotvars_to_unif_rr = <UNKNOWN_DEFAULT>
 
@@ -466,7 +466,7 @@ remora.fennel.wPhy = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.fennel.wSDet = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1769
+# source: Source/REMORA.cpp:1768
 # type=int; method=queryAdd
 remora.file_min_digits = 5
 
@@ -498,35 +498,35 @@ remora.gls_N = -1.0
 # type=Real; method=queryAdd
 remora.gls_P = 3.0
 
-# source: Source/REMORA_DataStruct.H:686
+# source: Source/REMORA_DataStruct.H:700
 # type=Real; method=queryAdd
 remora.gls_Pmin = 1.0e-12
 
-# source: Source/REMORA_DataStruct.H:689
+# source: Source/REMORA_DataStruct.H:703
 # type=Real; method=queryAdd
 remora.gls_c1 = 1.44
 
-# source: Source/REMORA_DataStruct.H:690
+# source: Source/REMORA_DataStruct.H:704
 # type=Real; method=queryAdd
 remora.gls_c2 = 1.92
 
-# source: Source/REMORA_DataStruct.H:691
+# source: Source/REMORA_DataStruct.H:705
 # type=Real; method=queryAdd
 remora.gls_c3m = -0.4
 
-# source: Source/REMORA_DataStruct.H:692
+# source: Source/REMORA_DataStruct.H:706
 # type=Real; method=queryAdd
 remora.gls_c3p = 1.0
 
-# source: Source/REMORA_DataStruct.H:688
+# source: Source/REMORA_DataStruct.H:702
 # type=Real; method=queryAdd
 remora.gls_cmu0 = 0.5477
 
-# source: Source/REMORA_DataStruct.H:693
+# source: Source/REMORA_DataStruct.H:707
 # type=Real; method=queryAdd
 remora.gls_sigk = 1.0
 
-# source: Source/REMORA_DataStruct.H:694
+# source: Source/REMORA_DataStruct.H:708
 # type=Real; method=queryAdd
 remora.gls_sigp = 1.3
 
@@ -554,7 +554,7 @@ remora.hires_init_level = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.horizontal_mixing_type = analytic
 
-# source: Source/REMORA_DataStruct.H:435
+# source: Source/REMORA_DataStruct.H:445
 # type=string; method=queryAdd
 remora.ic_bc_type = analytic
 
@@ -594,15 +594,15 @@ remora.longwave_netcdf_varname = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.longwave_radiation_flux = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:263
+# source: Source/REMORA_DataStruct.H:269
 # type=Real; method=query
 remora.lwrad = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:731
+# source: Source/REMORA_DataStruct.H:745
 # type=Real; method=queryAdd
 remora.m2nudg = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:732
+# source: Source/REMORA_DataStruct.H:746
 # type=Real; method=queryAdd
 remora.m3nudg = <UNKNOWN_DEFAULT>
 
@@ -674,7 +674,7 @@ remora.nc_river_file = "idRiv_riv_v0.2_classic64.nc"
 # type=int; method=queryAdd
 remora.ndtfast = 0
 
-# source: Source/REMORA.cpp:1747
+# source: Source/REMORA.cpp:1746
 # type=Real; method=query
 remora.netcdf_fill_value = <UNKNOWN_DEFAULT>
 
@@ -682,7 +682,7 @@ remora.netcdf_fill_value = <UNKNOWN_DEFAULT>
 # type=int; method=queryAdd
 remora.nscalar = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:733
+# source: Source/REMORA_DataStruct.H:747
 # type=Real; method=queryAdd
 remora.obcfac = <UNKNOWN_DEFAULT>
 
@@ -694,31 +694,31 @@ remora.omp_tile_size = 8 8 1024000
 # type=bool; method=queryAdd
 remora.output_forcing = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1835
+# source: Source/REMORA.cpp:1834
 # type=string; method=queryAdd
 remora.plot_file = plt
 
-# source: Source/REMORA.cpp:1836
+# source: Source/REMORA.cpp:1835
 # type=int; method=queryAdd
 remora.plot_int = 100
 
-# source: Source/REMORA.cpp:1837
+# source: Source/REMORA.cpp:1836
 # type=Real; method=queryAdd
 remora.plot_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1839
+# source: Source/REMORA.cpp:1838
 # type=bool; method=query
 remora.plot_nodal_data = true
 
-# source: Source/REMORA.cpp:1838
+# source: Source/REMORA.cpp:1837
 # type=bool; method=query
 remora.plot_staggered_vels = false
 
-# source: Source/REMORA.cpp:1746
+# source: Source/REMORA.cpp:1745
 # type=Real; method=query
 remora.plotfile_fill_value = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1842
+# source: Source/REMORA.cpp:1841
 # type=string; method=queryAdd
 remora.plotfile_type = amrex
 
@@ -830,7 +830,7 @@ remora.refinement_indicators_.value_greater = <REQUIRED>
 # type=Real; method=getarr
 remora.refinement_indicators_.value_less = <REQUIRED>
 
-# source: Source/REMORA.cpp:1748
+# source: Source/REMORA.cpp:1747
 # type=string; method=queryAdd
 remora.restart = <UNKNOWN_DEFAULT>
 
@@ -854,7 +854,7 @@ remora.smflux_type = analytic
 # type=Real; method=queryAdd
 remora.start_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1850
+# source: Source/REMORA.cpp:1849
 # type=int; method=queryAdd
 remora.steps_per_history_file = <UNKNOWN_DEFAULT>
 
@@ -866,7 +866,7 @@ remora.stop_time = 30000.0
 # type=int; method=queryAdd
 remora.sum_interval = -1
 
-# source: Source/REMORA.cpp:1768
+# source: Source/REMORA.cpp:1767
 # type=Real; method=queryAdd
 remora.sum_period = <UNKNOWN_DEFAULT>
 
@@ -874,7 +874,7 @@ remora.sum_period = <UNKNOWN_DEFAULT>
 # type=int; method=queryAdd
 remora.sum_precision = 6
 
-# Outputs forcing variables if true
+# Constant shortwave radiation [W/m^2]
 # type=Real; method=queryAdd
 remora.surface_radiation_flux = <UNKNOWN_DEFAULT>
 
@@ -966,11 +966,11 @@ remora.vwind = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.wind_type = analytic
 
-# source: Source/REMORA.cpp:1848
+# source: Source/REMORA.cpp:1847
 # type=bool; method=queryAdd
 remora.write_history_file = true
 
-# source: Source/REMORA_DataStruct.H:730
+# source: Source/REMORA_DataStruct.H:744
 # type=Real; method=queryAdd
 remora.znudg = <UNKNOWN_DEFAULT>
 
@@ -1405,7 +1405,7 @@ vismf.v = <UNKNOWN_DEFAULT>
 # type=bool; method=queryAdd
 amrex.abort_on_out_of_gpu_memory = false
 
-# source: Src/Base/AMReX.cpp:574
+# source: Src/Base/AMReX.cpp:575
 # type=unknown; method=queryAdd
 amrex.abort_on_unused_inputs = <UNKNOWN_DEFAULT>
 
@@ -1417,7 +1417,7 @@ amrex.async_out = false
 # type=int; method=queryAdd
 amrex.async_out_nfiles = 64
 
-# source: Src/Base/AMReX.cpp:573
+# source: Src/Base/AMReX.cpp:574
 # type=unknown; method=query
 amrex.call_addr2line = <UNKNOWN_DEFAULT>
 
@@ -1437,43 +1437,43 @@ amrex.fpe_trap_overflow = false
 # type=unknown; method=queryAdd
 amrex.fpe_trap_zero = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:590
+# source: Src/Base/AMReX.cpp:591
 # type=unknown; method=queryAdd
 amrex.handle_sigabrt = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:591
+# source: Src/Base/AMReX.cpp:592
 # type=unknown; method=queryAdd
 amrex.handle_sigfpe = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:592
+# source: Src/Base/AMReX.cpp:593
 # type=unknown; method=queryAdd
 amrex.handle_sigill = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:589
+# source: Src/Base/AMReX.cpp:590
 # type=unknown; method=queryAdd
 amrex.handle_sigint = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:587
+# source: Src/Base/AMReX.cpp:588
 # type=unknown; method=queryAdd
 amrex.handle_sigsegv = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:588
+# source: Src/Base/AMReX.cpp:589
 # type=unknown; method=queryAdd
 amrex.handle_sigterm = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:683
+# source: Src/Base/AMReX.cpp:684
 # type=bool; method=queryAdd
 amrex.hypre_spgemm_use_vendor = false
 
-# source: Src/Base/AMReX.cpp:684
+# source: Src/Base/AMReX.cpp:685
 # type=bool; method=queryAdd
 amrex.hypre_spmv_use_vendor = false
 
-# source: Src/Base/AMReX.cpp:685
+# source: Src/Base/AMReX.cpp:686
 # type=bool; method=queryAdd
 amrex.hypre_sptrans_use_vendor = false
 
-# source: Src/Base/AMReX.cpp:681
+# source: Src/Base/AMReX.cpp:682
 # type=bool; method=queryAdd
 amrex.init_hypre = true
 
@@ -1505,19 +1505,19 @@ amrex.parmparse.v = <UNKNOWN_DEFAULT>
 # type=int; method=queryAdd
 amrex.pout_int = 1
 
-# source: Src/Base/AMReX.cpp:570
+# source: Src/Base/AMReX.cpp:571
 # type=unknown; method=query
 amrex.regtest_reduction = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:571
+# source: Src/Base/AMReX.cpp:572
 # type=unknown; method=queryAdd
 amrex.signal_handling = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX_ParallelDescriptor.cpp:1610
+# source: Src/Base/AMReX_ParallelDescriptor.cpp:1612
 # type=int; method=query
 amrex.team.reduce = 0
 
-# source: Src/Base/AMReX_ParallelDescriptor.cpp:1609
+# source: Src/Base/AMReX_ParallelDescriptor.cpp:1611
 # type=int; method=query
 amrex.team.size = 1
 
@@ -1585,11 +1585,11 @@ amrex.the_pinned_arena_init_size = 0
 # type=Long; method=queryAdd
 amrex.the_pinned_arena_release_threshold = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:572
+# source: Src/Base/AMReX.cpp:573
 # type=unknown; method=queryAdd
 amrex.throw_exception = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX_ParallelDescriptor.cpp:1583
+# source: Src/Base/AMReX_ParallelDescriptor.cpp:1585
 # type=bool; method=queryAdd
 amrex.use_gpu_aware_mpi = false
 
@@ -1682,7 +1682,7 @@ device.v = 0
 #==============================================================================
 # TINY PROFILER PARAMETERS
 #==============================================================================
-# source: Src/Base/AMReX_TinyProfiler.cpp:324
+# source: Src/Base/AMReX_TinyProfiler.cpp:353
 # type=bool; method=queryAdd
 tiny_profiler.device_synchronize_around_region = false
 
@@ -1690,13 +1690,13 @@ tiny_profiler.device_synchronize_around_region = false
 # type=bool; method=queryAdd
 tiny_profiler.enabled = true
 
-# source: Src/Base/AMReX_TinyProfiler.cpp:355
+# source: Src/Base/AMReX_TinyProfiler.cpp:384
 # type=bool; method=queryAdd
 tiny_profiler.memprof_enabled = true
 
 # the timer and memory reports (both opened in append mode) coexist.
 # type=return; method=query
-tiny_profiler.output_file = <UNKNOWN_DEFAULT>
+tiny_profiler.output_file = stdout
 
 # Specify the maximum percentage of inclusive time that the "Other" section in the output can have (default 1%)
 # type=Real; method=queryAdd
@@ -1819,29 +1819,29 @@ driver.atm2ocn_mode = state
 #==============================================================================
 # NUMBLOCKS PARAMETERS
 #==============================================================================
-# source: Src/Base/AMReX_GpuDevice.cpp:662
+# source: Src/Base/AMReX_GpuDevice.cpp:667
 # type=int; method=query
 numBlocks.x = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:663
+# source: Src/Base/AMReX_GpuDevice.cpp:668
 # type=int; method=query
 numBlocks.y = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:664
+# source: Src/Base/AMReX_GpuDevice.cpp:669
 # type=int; method=query
 numBlocks.z = 0
 
 #==============================================================================
 # NUMTHREADS PARAMETERS
 #==============================================================================
-# source: Src/Base/AMReX_GpuDevice.cpp:650
+# source: Src/Base/AMReX_GpuDevice.cpp:655
 # type=int; method=query
 numThreads.x = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:651
+# source: Src/Base/AMReX_GpuDevice.cpp:656
 # type=int; method=query
 numThreads.y = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:652
+# source: Src/Base/AMReX_GpuDevice.cpp:657
 # type=int; method=query
 numThreads.z = 0

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -132,6 +132,17 @@ public:
     // driver-injected keys. Safe any time before the first step: the lane is
     // allocated whenever bulk fluxes are on, independent of lwrad_type.
     void SetLongwaveFromDriver ();
+
+    // Per state lane, whether the deck named its forcing - either the selector
+    // (remora.<x>_type, its legacy aliases, remora.wind_type) or the constant
+    // (remora.air_humidity and friends). A coupling driver uses it to leave such
+    // a lane with the deck instead of overriding it with atmospheric data.
+    //
+    // Not answerable from ParmParse afterwards: queryAdd materializes the
+    // defaults. See SolverChoice::bulk_flux_type_specified.
+    void GetDeckConfiguredAtmosStateLanes (
+        std::array<bool, AtmosState::NumTypes>& deck_configured) const;
+
     // Driver currently consumes BoxArray/DistributionMapping only. If we later
     // need exact copy semantics, promote these to expose IndexType/ngrow
     // explicitly or return the underlying MultiFab pointer/reference instead.

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1193,11 +1193,10 @@ REMORA::set_surface_state (int lev)
 
     auto& bulk_flux_type = solverChoice.bulk_flux_type;
 
-    for (int n=0; n < AtmosState::NumTypes; n++) {
-        if (driver_atmos_state_from_driver[n]) {
-            amrex::Abort("Reached set_surface_state() but variables have already been specified from driver!");
-        }
-    }
+    // Every update below skips driver-supplied lanes individually, on
+    // !driver_atmos_state_from_driver[...]. This used to abort outright if any
+    // lane was driver-supplied, which made the function unreachable in a coupled
+    // run and so denied the *withheld* lanes the fallback those guards provide.
 
 #ifdef REMORA_USE_NETCDF
     auto update_from_netcdf = [&](std::unique_ptr<NCTimeSeries>& data_from_file,

--- a/Source/REMORA_Coupling.cpp
+++ b/Source/REMORA_Coupling.cpp
@@ -266,6 +266,34 @@ REMORA::SetLongwaveFromDriver ()
 }
 
 void
+REMORA::GetDeckConfiguredAtmosStateLanes (
+    std::array<bool, AtmosState::NumTypes>& deck_configured) const
+{
+    // AtmosState and BulkFlux agree on lanes 0-8 today, but they are separate
+    // enums of separate lengths (BulkFlux carries EminusP, which has no driver
+    // lane). Map explicitly, so inserting into either breaks the build here
+    // rather than silently transposing the answer.
+    static constexpr std::array<int, AtmosState::NumTypes> lane_to_bulk_flux {{
+        BulkFlux::Uwind, // AtmosState::Uwind
+        BulkFlux::Vwind, // AtmosState::Vwind
+        BulkFlux::Pair,  // AtmosState::Pair
+        BulkFlux::Qair,  // AtmosState::Qair
+        BulkFlux::Tair,  // AtmosState::Tair
+        BulkFlux::Cloud, // AtmosState::Cloud
+        BulkFlux::Rain,  // AtmosState::Rain
+        BulkFlux::SWrad, // AtmosState::SWrad
+        BulkFlux::LWrad  // AtmosState::LWrad
+    }};
+
+    deck_configured.fill(false);
+    for (int lane = 0; lane < AtmosState::NumTypes; ++lane) {
+        const int idx = lane_to_bulk_flux[lane];
+        deck_configured[lane] = solverChoice.bulk_flux_type_specified[idx] ||
+                                solverChoice.bulk_flux_value_specified[idx];
+    }
+}
+
+void
 REMORA::SetDriverAtmosToOceanForcingMode (DriverAtmosForcingMode mode)
 {
     driver_atmos_forcing_mode = mode;

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -253,21 +253,27 @@ struct SolverChoice {
         }
         // Outputs forcing variables if true
         pp.queryAdd("output_forcing", output_forcing);
-        pp.queryAdd("air_pressure",Pair);
-        pp.queryAdd("air_temperature",Tair);
-        pp.queryAdd("air_humidity",Hair);
-        pp.queryAdd("surface_radiation_flux",srflux);
-        pp.queryAdd("uwind", Uwind);
-        pp.queryAdd("vwind", Vwind);
-        pp.queryAdd("longwave_radiation_flux", longwave_rad);
-        pp.query("lwrad", longwave_rad);
-        pp.queryAdd("longwave_down", longwave_down);
-        pp.queryAdd("longwave_is_net", longwave_is_net);
+        // The query return is the only moment "did the deck name this?" is
+        // knowable; see bulk_flux_value_specified. Legacy aliases (lwrad,
+        // eminusp_value) feed the same lane, so they count too.
+        auto value_specified = [&](int idx, int existed) {
+            if (existed) { bulk_flux_value_specified[idx] = true; }
+        };
+        value_specified(BulkFlux::Pair,  pp.queryAdd("air_pressure",Pair));
+        value_specified(BulkFlux::Tair,  pp.queryAdd("air_temperature",Tair));
+        value_specified(BulkFlux::Qair,  pp.queryAdd("air_humidity",Hair));
+        value_specified(BulkFlux::SWrad, pp.queryAdd("surface_radiation_flux",srflux));
+        value_specified(BulkFlux::Uwind, pp.queryAdd("uwind", Uwind));
+        value_specified(BulkFlux::Vwind, pp.queryAdd("vwind", Vwind));
+        value_specified(BulkFlux::LWrad, pp.queryAdd("longwave_radiation_flux", longwave_rad));
+        value_specified(BulkFlux::LWrad, pp.query("lwrad", longwave_rad));
+        value_specified(BulkFlux::LWrad, pp.queryAdd("longwave_down", longwave_down));
+        value_specified(BulkFlux::LWrad, pp.queryAdd("longwave_is_net", longwave_is_net));
         pp.queryAdd("longwave_netcdf_varname", longwave_netcdf_varname);
-        pp.queryAdd("cloud",cloud);
-        pp.queryAdd("rain",rain);
-        pp.queryAdd("EminusP", EminusP);
-        pp.query("eminusp_value", EminusP);
+        value_specified(BulkFlux::Cloud, pp.queryAdd("cloud",cloud));
+        value_specified(BulkFlux::Rain,  pp.queryAdd("rain",rain));
+        value_specified(BulkFlux::EminusP, pp.queryAdd("EminusP", EminusP));
+        value_specified(BulkFlux::EminusP, pp.query("eminusp_value", EminusP));
         pp.queryAdd("blk_ZQ",blk_ZQ);
         pp.queryAdd("blk_ZT",blk_ZT);
         pp.queryAdd("blk_ZW",blk_ZW);
@@ -304,6 +310,7 @@ struct SolverChoice {
                 bulk_flux_type[input.idx] = parse_bulk_forcing_type(type_string,
                                                                      "remora." + std::string(input.name),
                                                                      input.allow_computed);
+                bulk_flux_type_specified[input.idx] = true;
                 if (input.idx == BulkFlux::Uwind) {
                     uwind_type_specified = true;
                 } else if (input.idx == BulkFlux::Vwind) {
@@ -330,6 +337,7 @@ struct SolverChoice {
                 bulk_flux_type[input.idx] = parse_bulk_forcing_type(type_string,
                                                                      "remora." + std::string(input.name),
                                                                      input.allow_computed);
+                bulk_flux_type_specified[input.idx] = true;
             }
         }
 
@@ -348,12 +356,14 @@ struct SolverChoice {
             bool from_netcdf = false;
             if (pp.query(input.name, from_netcdf) && from_netcdf) {
                 bulk_flux_type[input.idx] = BulkForcingType::netcdf;
+                bulk_flux_type_specified[input.idx] = true;
             }
         }
 
         bool legacy_longwave_netcdf_is_net = false;
         if (pp.query("longwave_netcdf_is_net", legacy_longwave_netcdf_is_net) && legacy_longwave_netcdf_is_net) {
             longwave_is_net = true;
+            bulk_flux_type_specified[BulkFlux::LWrad] = true;
             if (bulk_flux_type[BulkFlux::LWrad] == BulkForcingType::computed) {
                 bulk_flux_type[BulkFlux::LWrad] = BulkForcingType::netcdf;
             }
@@ -528,6 +538,10 @@ struct SolverChoice {
         if (wind_specified) {
             const auto specified_wind_bulk_type = (wind_type == WindType::netcdf) ?
                 BulkForcingType::netcdf : BulkForcingType::analytic;
+            // wind_type names both wind lanes, so it counts as specifying them
+            // even with the per-lane keys absent.
+            bulk_flux_type_specified[BulkFlux::Uwind] = true;
+            bulk_flux_type_specified[BulkFlux::Vwind] = true;
             if (!uwind_type_specified) {
                 bulk_flux_type[BulkFlux::Uwind] = specified_wind_bulk_type;
             }
@@ -864,6 +878,16 @@ struct SolverChoice {
         BulkForcingType::computed, // LWrad defaults to the internal longwave formula
         BulkForcingType::computed  // EminusP defaults to bulk evap-rain diagnostic
     }};
+
+    // Which bulk-flux inputs the deck actually named, rather than defaulted to.
+    //
+    // Not recoverable afterwards: init_params reads these with queryAdd, which
+    // writes the default back into the table on a miss, so contains() then says
+    // "yes" for all of them. A coupling driver needs the distinction to decide
+    // whether to override a lane, so it is recorded here during parsing.
+    std::array<bool, BulkFlux::NumTypes> bulk_flux_type_specified {};
+    std::array<bool, BulkFlux::NumTypes> bulk_flux_value_specified {};
+
     bool        longwave_is_net      = false;
     bool        qair_is_percent       = false;
     std::string longwave_netcdf_varname = "lwrad";

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -107,15 +107,23 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
         MultiFab::Copy(W_new,W_old,0,0,W_new.nComp(),W_new.nGrowVect());
     }
 
-    // If we're running in coupled mode, surface state and fluxes were already set
-    // Otherwise, if doing bulk fluxes, set winds/temp/etc
-    // And if not doing bulk fluxes, directly set surface fluxes
-    if (running_with_coupling_driver) {
-        // Surface stress and heat/moisture fluxes were already populated from the driver.
-    } else if (solverChoice.bulk_fluxes) {
+    // Refresh the atmospheric forcing fields feeding the bulk-flux path.
+    //
+    // A coupled run needs this too, and used to skip it entirely. The driver
+    // supplies only the lanes its atmosphere can fill and withholds the rest,
+    // expecting those to keep this deck's own forcing - NetCDF series included.
+    // set_surface_state is already per-lane, so the supplied ones are left
+    // alone; skipping it wholesale froze every withheld lane at its
+    // level-creation constant.
+    //
+    // The gate mirrors the bulk_fluxes() call below: in driver flux mode these
+    // fields are never read.
+    if (solverChoice.bulk_fluxes &&
+        (!running_with_coupling_driver ||
+         DriverUsesStateForcing(driver_atmos_forcing_mode))) {
         set_surface_state(lev);
-    } else {
-        set_smflux(lev);
+    } else if (!running_with_coupling_driver && !solverChoice.bulk_fluxes) {
+        set_smflux(lev); // uncoupled, no bulk fluxes: set surface fluxes directly
     }
 
     auto N = Geom(lev).Domain().size()[2]-1; // Number of vertical "levs" aka, NZ


### PR DESCRIPTION
## Why

A coupling driver supplies only the atmospheric forcing lanes its atmosphere can
actually produce, and withholds the rest so REMORA keeps its own forcing for
them. Two things stopped that working.

`set_surface_state()` was skipped wholesale whenever `running_with_coupling_driver`
was set, and aborted if any lane was driver-supplied. Both halves of that made the
per-lane `!driver_atmos_state_from_driver[...]` guards inside it unreachable in a
coupled run: a withheld lane never got its NetCDF or analytic update and simply
froze at its level-creation constant. A deck with `remora.rain_type = netcdf`
silently ran on a constant instead.

Separately, nothing recorded whether the deck actually named a lane's forcing.
`init_params` reads the selectors and constants with `queryAdd`, which writes the
defaults back into the ParmParse table, so `contains()` afterwards answers "yes"
for all of them. The `int` `queryAdd` returns is the only moment the distinction
is knowable, and it was discarded.

## What

- `SolverChoice::bulk_flux_type_specified` / `bulk_flux_value_specified`, set at
  every site that overrides a lane's selector or constant, including the legacy
  aliases (`srflx_type`, `longwave_type`, `*_from_netcdf`, `longwave_netcdf_is_net`)
  and `remora.wind_type`, which names both wind lanes.
- `REMORA::GetDeckConfiguredAtmosStateLanes()` exposes that per `AtmosState` lane.
  `AtmosState` and `BulkFlux` are mapped explicitly rather than index-cast: they
  are separate enums of separate lengths, and `BulkFlux` carries `EminusP`, which
  has no driver lane.
- `setup_step` now calls `set_surface_state()` in coupled state mode, gated the
  same way the `bulk_fluxes()` call below it already is, and the blanket abort is
  gone. The existing per-lane guards do the rest, so driver-supplied lanes are
  still left alone.

No behaviour change for uncoupled runs: the new gate reduces to the old
`bulk_fluxes ? set_surface_state : set_smflux` when
`running_with_coupling_driver` is false, and the `_specified` arrays are
write-only unless a driver asks.

## Testing

Built and exercised through the erf-remora-driver superbuild. On a coupled
Upwelling deck, `vec_qair` now holds REMORA's own `Hair` default: the run is
bit-identical (fcompare) to one with `remora.air_humidity = 0.776` set
explicitly, and differs from `= 0.0` by 0.118 degC in temp after one ocean step.
Driver-side restart and MPI-rank reproducer suites pass.
