### PR TITLE
Make particle init consistently per-tile (fixes #657)

### DIFF
--- a/Source/Particles/REMORA_PC_Init.cpp
+++ b/Source/Particles/REMORA_PC_Init.cpp
@@ -131,30 +131,40 @@ void REMORAPC::initializeParticlesUniformDistributionInBox (const std::unique_pt
     for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi) {
         const Box& tile_box  = mfi.tilebox();
 
-        int np = 0;
-        {
-            int ncell = num_particles[mfi].numPts();
-            const int* in = num_particles[mfi].dataPtr();
-            int* out = offsets[mfi].dataPtr();
-            np = Scan::PrefixSum<int>( ncell,
-                                       [=] AMREX_GPU_DEVICE (int i) -> int { return in[i]; },
-                                       [=] AMREX_GPU_DEVICE (int i, int const &x) { out[i] = x; },
-                                       Scan::Type::exclusive,
-                                       Scan::retSum );
-        }
-        auto offset_arr = offsets[mfi].array();
+        // Keep this loop per *tile*: the prefix sum, the offsets it writes, the resize
+        // and the fill must all describe tile_box. Grid-wide quantities here (scanning
+        // the whole num_particles fab, say) agree only while
+        // ParticleContainerBase::do_tiling is false; with tiling on they oversize every
+        // tile and race on the shared offsets fab.
+        const auto num_particles_arr = num_particles[mfi].const_array();
+        auto       offset_arr        = offsets[mfi].array();
+
+        // atOffset walks tile_box with i fastest, so with one tile per grid the scan
+        // sees exactly the fab's own layout.
+        const int np = Scan::PrefixSum<int>( static_cast<int>(tile_box.numPts()),
+                           [=] AMREX_GPU_DEVICE (int idx) -> int {
+                               return num_particles_arr(tile_box.atOffset(idx));
+                           },
+                           [=] AMREX_GPU_DEVICE (int idx, int const &x) {
+                               offset_arr(tile_box.atOffset(idx)) = x;
+                           },
+                           Scan::Type::exclusive,
+                           Scan::retSum );
 
         // already defined in the serial pass above
         auto& particle_tile = ParticlesAt(lev, mfi);
         particle_tile.resize(np);
+
+        // Nothing to place: a tile (or, with tiling off, a whole grid) can lie entirely
+        // outside particle_init_domain. Bail before taking &aos[0] on an empty tile.
+        if (np == 0) { continue; }
+
         auto aos = &particle_tile.GetArrayOfStructs()[0];
         auto& soa = particle_tile.GetStructOfArrays();
         auto* vx_ptr = soa.GetRealData(REMORAParticlesRealIdxSoA::vx).data();
         auto* vy_ptr = soa.GetRealData(REMORAParticlesRealIdxSoA::vy).data();
         auto* vz_ptr = soa.GetRealData(REMORAParticlesRealIdxSoA::vz).data();
         auto* mass_ptr = soa.GetRealData(REMORAParticlesRealIdxSoA::mass).data();
-
-        const auto num_particles_arr = num_particles[mfi].array();
 
         auto my_proc = ParallelDescriptor::MyProc();
         Long pid;


### PR DESCRIPTION
The second MFIter loop in initializeParticlesUniformDistributionInBox mixed per-grid and per-tile quantities: it took the prefix sum over the whole num_particles fab (numPts()/dataPtr()) and sized the particle tile from that grid-wide total, while the ParallelFor that fills the particles only visited mfi.tilebox().

The two agree only because ParticleContainerBase::do_tiling defaults to false, giving one tile per grid. With particle tiling on, every tile of a grid allocated the whole grid's particle count but filled only its own cells, so a grid split into N tiles wrote N times too many particles, all but 1/N of them uninitialized. Each tile also recomputed the same grid-wide prefix sum and wrote the entire shared offsets fab, racing under OpenMP. The corruption was silent: TotalNumberOfParticles() skips invalid ids, so REMORA printed the right count while writing 4x that many into the checkpoint.

Run the scan over mfi.tilebox() instead, writing offsets only into that tile's region, so np, the offsets, the resize and the fill all describe the same box. Box::atOffset supplies the index decode; it walks with i fastest, matching the linear layout the old dataPtr() scan relied on, so with one tile per grid the traversal order is unchanged.

Also skip tiles with no particles. &particle_tile.GetArrayOfStructs()[0] on an empty tile forms &m_data[0] on a null pointer, which UBSan flags. This is not new -- np was already 0 for any grid lying entirely outside particle_init_domain -- but tiling makes empty regions far more common. Bailing right after the resize also skips a serializing omp critical on NextID and a wasted kernel launch.