### PR TITLE
Land-sea masking across refinement levels

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -478,7 +478,7 @@ cannot disagree about the coastline. With ``remora.hires_grid_level < 0`` it is 
 and injected piecewise-constant onto finer levels. With ``remora.hires_grid_level > 0`` it is
 given on that level over the whole domain, from the same source as the high-resolution
 bathymetry; levels at or below take it coarsened down, levels above are injected. Without that
-lane a refined level inherits a coastline only as well resolved as level 0 resolves it, even
+it a refined level inherits a coastline only as well resolved as level 0 resolves it, even
 where the bathymetry is not.
 
 Coarsening takes **a coarse cell as land only if all its fine cells are land**; an arithmetic

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -471,28 +471,26 @@ A land/sea mask marks each point as water (1) or land (0). ``remora.mask_type`` 
 source: ``none`` leaves everything water, ``analytic`` calls the problem's mask function, and
 ``netcdf`` reads ``mask_rho`` from the grid file. Only the rho-point mask is ever read or
 given analytically; the u-, v- and psi-point masks are derived from it as ROMS ``set_masks.F``
-defines them, so the two cannot disagree.
+defines them.
 
 As with bathymetry, the mask is specified once and every other level derived from it, so levels
 cannot disagree about the coastline. With ``remora.hires_grid_level < 0`` it is given at level 0
 and injected piecewise-constant onto finer levels. With ``remora.hires_grid_level > 0`` it is
 given on that level over the whole domain, from the same source as the high-resolution
-bathymetry; levels at or below take it coarsened down, levels above are injected. Without that
-it a refined level inherits a coastline only as well resolved as level 0 resolves it, even
-where the bathymetry is not.
+bathymetry; levels below take it coarsened down, levels above are injected.
 
 Coarsening takes **a coarse cell as land only if all its fine cells are land**; an arithmetic
 mean would give fractional values, and the mask must stay exactly 0 or 1.
 
-Under two-way coupling the fine-to-coarse average is mask-weighted as in ROMS: fine values times
-the fine mask, divided by the number of *wet* fine points rather than the block size, then
+Under two-way coupling the fine-to-coarse average is mask-weighted as in ROMS: fine values multiplied
+the fine mask, divided by the number of *wet* fine points, then
 multiplied by the coarse mask. A partly-covered coarse cell thus takes the mean of the water
 under it, not a value pulled toward zero by the land beside it. This is not conservative; ROMS
 makes the same trade deliberately.
 
 ``remora.check_mask_consistency`` is a **debug option**, off by default. It validates the masks
 after initialization or restart and after each regrid: that they hold only 0 and 1 (psi points
-may also be 2, the free-slip factor), that no water cell has a non-positive depth, and that no
+may also be 2), that no water cell has a non-positive depth, and that no
 coarse water point sits over fine points that are all land, which would leave the mask-weighted
 average nothing to divide by. It checks the machinery rather than the input, so it is worth
 enabling when bringing up a new grid but not in production; the regression suite runs with it on.

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -496,8 +496,7 @@ may also be 2, the free-slip factor), that no water cell has a non-positive dept
 coarse water point sits over fine points that are all land, which would leave the mask-weighted
 average nothing to divide by. It checks the machinery rather than the input, so it is worth
 enabling when bringing up a new grid but not in production; the regression suite runs with it on.
-``remora.mask_consistency`` chooses what happens on failure, and is read only when the check is
-on.
+``remora.mask_consistency`` chooses what happens on failure.
 
 .. _list-of-parameters-mask:
 

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -462,6 +462,68 @@ Examples of Usage
    | The dimensions of all the final grids will be multiples of 32 at
      level 0, multiples of 16 at level 1, and multiples of 8 at level 2.
 
+.. _sec:masking:
+
+Land/Sea Masking
+================
+
+A land/sea mask marks each point as water (1) or land (0). ``remora.mask_type`` selects the
+source: ``none`` leaves everything water, ``analytic`` calls the problem's mask function, and
+``netcdf`` reads ``mask_rho``, ``mask_u`` and ``mask_v`` from the grid file.
+
+As with bathymetry, the mask is specified once and every other level derived from it, so levels
+cannot disagree about the coastline. With ``remora.hires_grid_level < 0`` it is given at level 0
+and injected piecewise-constant onto finer levels. With ``remora.hires_grid_level > 0`` it is
+given on that level over the whole domain, from the same source as the high-resolution
+bathymetry; levels at or below take it coarsened down, levels above are injected. Without that
+lane a refined level inherits a coastline only as well resolved as level 0 resolves it, even
+where the bathymetry is not.
+
+Coarsening takes **a coarse cell as land only if all its fine cells are land**; an arithmetic
+mean would give fractional values, and the mask must stay exactly 0 or 1.
+
+Under two-way coupling the fine-to-coarse average is mask-weighted as in ROMS: fine values times
+the fine mask, divided by the number of *wet* fine points rather than the block size, then
+multiplied by the coarse mask. A partly-covered coarse cell thus takes the mean of the water
+under it, not a value pulled toward zero by the land beside it. This is not conservative; ROMS
+makes the same trade deliberately.
+
+``remora.check_mask_consistency`` is a **debug option**, off by default. It validates the masks
+after initialization or restart and after each regrid: that they hold only 0 and 1 (psi points
+may also be 2, the free-slip factor), that no water cell has a non-positive depth, and that no
+coarse water point sits over fine points that are all land, which would leave the mask-weighted
+average nothing to divide by. It checks the machinery rather than the input, so it is worth
+enabling when bringing up a new grid but not in production; the regression suite runs with it on.
+``remora.mask_consistency`` chooses what happens on failure, and is read only when the check is
+on.
+
+.. _list-of-parameters-mask:
+
+List of Parameters
+------------------
+
++------------------------------------------+----------------------------------------+------------------------+----------------+
+| Parameter                                | Definition                             | Acceptable             | Default        |
+|                                          |                                        |                        |                |
+|                                          |                                        | Values                 |                |
++==========================================+========================================+========================+================+
+| **remora.mask_type**                     | Where the land/sea mask comes          | none,                  | none, or       |
+|                                          |                                        |                        |                |
+|                                          | from                                   | analytic,              | netcdf if      |
+|                                          |                                        |                        |                |
+|                                          |                                        | netcdf                 | ic_type is     |
+|                                          |                                        |                        |                |
+|                                          |                                        |                        | netcdf         |
++------------------------------------------+----------------------------------------+------------------------+----------------+
+| **remora.check_mask_consistency**        | Debug option: validate the masks       | true / false           | false          |
+|                                          |                                        |                        |                |
+|                                          | at startup and after each regrid       |                        |                |
++------------------------------------------+----------------------------------------+------------------------+----------------+
+| **remora.mask_consistency**              | What to do when that check fails.      | abort, warn            | abort          |
+|                                          |                                        |                        |                |
+|                                          | Only read when the check is on         |                        |                |
++------------------------------------------+----------------------------------------+------------------------+----------------+
+
 Simulation Time
 ===============
 

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -469,7 +469,9 @@ Land/Sea Masking
 
 A land/sea mask marks each point as water (1) or land (0). ``remora.mask_type`` selects the
 source: ``none`` leaves everything water, ``analytic`` calls the problem's mask function, and
-``netcdf`` reads ``mask_rho``, ``mask_u`` and ``mask_v`` from the grid file.
+``netcdf`` reads ``mask_rho`` from the grid file. Only the rho-point mask is ever read or
+given analytically; the u-, v- and psi-point masks are derived from it as ROMS ``set_masks.F``
+defines them, so the two cannot disagree.
 
 As with bathymetry, the mask is specified once and every other level derived from it, so levels
 cannot disagree about the coastline. With ``remora.hires_grid_level < 0`` it is given at level 0

--- a/Docs/sphinx_doc/MeshRefinement.rst
+++ b/Docs/sphinx_doc/MeshRefinement.rst
@@ -171,6 +171,9 @@ Masked Regions and Tagging
 Masked cells and the land-sea boundary are untagged for refinement even if they otherwise meet
 refinement criteria. They may still be refined, but they will not be forced to be refined.
 
+How the mask itself is carried across levels, and how it weights the two-way average, is described
+in :ref:`Land/Sea Masking <sec:masking>`.
+
 Coupling Types
 --------------
 

--- a/Docs/sphinx_doc/RegressionTests.rst
+++ b/Docs/sphinx_doc/RegressionTests.rst
@@ -155,6 +155,15 @@ what a misspelled parameter name did in ``Exec/GulfRefinementTest`` before this 
 *Misconfiguration.* Five lanes assert that a bad combination fails with the message that names it, rather
 than segfaulting, writing out of bounds, or running on data it quietly ignored.
 
+*Partial coverage.* The two ``DogboneAnalytic_MLmask`` lanes are the only ones where a coarse cell is
+partly land and partly water, which is what the mask-weighted average-down exists for. Producing one
+takes both ``hires_grid_level``, so the coastline is resolved on the refined level rather than injected
+from level 0, and a static refinement box over the coast, since velocity-tagged refinement never covers
+it -- masked cells and the land-sea boundary are untagged. Their exact solution is rest, so they need no
+reference file: ``plt00010`` must equal ``plt00000``. A plain arithmetic average-down lets the zeroed
+fine land cells drag those coarse cells off their initial value, breaking stationarity by about 1e-2 in
+salinity and velocity, so a lost mask weighting fails loudly rather than matching its own snapshot.
+
 +---------------------------------+----------+---------------------------------------------------------+
 | Test                            | nx ny nz | What it asserts                                         |
 +=================================+==========+=========================================================+
@@ -191,6 +200,12 @@ than segfaulting, writing out of bounds, or running on data it quietly ignored.
 | Seamount_hires_grid_zero_abort  | 49 48 13 | a hires level of 0 is rejected rather than              |
 |                                 |          |                                                         |
 |                                 |          | dereferencing an array only allocated above level 0     |
++---------------------------------+----------+---------------------------------------------------------+
+| DogboneAnalytic_MLmask          | 42 15 16 | coarse cells that are 6 water of 9 keep their exact     |
+|                                 |          |                                                         |
+|                                 |          | values, so a run at rest stays at rest (ratio 3)        |
++---------------------------------+----------+---------------------------------------------------------+
+| DogboneAnalytic_MLmask_rr2      | 42 15 16 | the same at ratio 2, where the blocks are half water    |
 +---------------------------------+----------+---------------------------------------------------------+
 
 ``Upwelling_Fennel_hires_init`` runs to zero steps: it writes the initial plotfile and exits, which takes

--- a/Docs/sphinx_doc/RegressionTests.rst
+++ b/Docs/sphinx_doc/RegressionTests.rst
@@ -136,33 +136,35 @@ level 0 (see :ref:`Inputs<sec:Inputs>`). They are analytic, so they need no NetC
 data. ``remora.hires_init_level`` is NetCDF-only and is covered by the developer lanes in
 ``Exec/GulfRefinementTest`` instead, described in that directory's ``README.rst``.
 
-The lanes come in three flavours, because "the run completed" is not evidence that an average-down
+The lanes come in three flavors, because "the run completed" is not evidence that an average-down
 happened, let alone that it was right.
 
 *Transparency.* ``ChannelTest`` sets ``h = 50`` and ``DogboneAnalytic`` sets ``h = 10``, both with
 ``setVal``, covering every grow cell. The mean over any refined block is then the same constant, so the
 hires path must reproduce the corresponding non-hires baseline exactly. These lanes compare against the
 existing ``Channel_Test`` and ``DogboneAnalytic_MLvel`` reference files rather than storing new ones.
-They deliberately *cannot* detect a hires flag that is being ignored -- that is the next flavour's job.
+They deliberately *cannot* detect a hires flag that is being ignored -- that is the next flavor's job.
 
 *Discrimination.* ``Seamount``'s bathymetry is a Gaussian in physical position, so the mean of the
 refined samples in a coarse cell is not the coarse midpoint sample. ``Seamount_hires`` must therefore
 both match its own reference and **differ** from the plain ``Seamount`` one; the difference is about
 16 m at the summit, some 12 orders of magnitude above the comparison tolerance. Without that second
-clause a feature that silently stops taking effect still matches its own snapshot -- which is exactly
-what a misspelled parameter name did in ``Exec/GulfRefinementTest`` before this was tested.
+clause a feature that silently stops taking effect still matches its own snapshot.
 
 *Misconfiguration.* Five lanes assert that a bad combination fails with the message that names it, rather
 than segfaulting, writing out of bounds, or running on data it quietly ignored.
 
-*Partial coverage.* The two ``DogboneAnalytic_MLmask`` tests are the only ones where a coarse cell is
-partly land and partly water, which is what the mask-weighted average-down exists for. Producing one
-takes both ``hires_grid_level``, so the coastline is resolved on the refined level rather than injected
-from level 0, and a static refinement box over the coast, since velocity-tagged refinement never covers
-it -- masked cells and the land-sea boundary are untagged. Their exact solution is rest, so they need no
-reference file: ``plt00010`` must equal ``plt00000``. A plain arithmetic average-down lets the zeroed
-fine land cells drag those coarse cells off their initial value, breaking stationarity by about 1e-2 in
-salinity and velocity, so a lost mask weighting fails loudly rather than matching its own snapshot.
+*Partial coverage.* The two ``DogboneAnalytic_MLmask`` tests are the only ones in which a coarse cell is
+part land and part water, which is the case the mask-weighted average-down exists for. Producing such a
+cell in the Dogbone case takes two things: ``hires_grid_level``, which resolves the coastline on the
+refined level instead of injecting it from level 0, and a static box that places the fine grids over
+the coast. The box is static because these cases are at rest, so a field-based indicator such as
+``DogboneAnalytic_MLvel``'s ``x_velocity > 0.05`` would tag nothing anywhere; it also fixes which coarse
+cells come out partly wet, and with ``amr.regrid_int = -1`` they cannot move between the two plotfiles.
+Being at rest is also why they need no reference file of their own -- ``plt00010`` must equal ``plt00000``
+to 1e-14. Under a plain arithmetic average-down the zeroed fine land cells drag the partly covered coarse
+cells off that initial value and stationarity breaks by about 1e-2 in salinity and velocity, so a
+lost mask weighting fails the comparison rather than quietly agreeing with its own snapshot.
 
 +---------------------------------+----------+---------------------------------------------------------+
 | Test                            | nx ny nz | What it asserts                                         |

--- a/Docs/sphinx_doc/RegressionTests.rst
+++ b/Docs/sphinx_doc/RegressionTests.rst
@@ -155,7 +155,7 @@ what a misspelled parameter name did in ``Exec/GulfRefinementTest`` before this 
 *Misconfiguration.* Five lanes assert that a bad combination fails with the message that names it, rather
 than segfaulting, writing out of bounds, or running on data it quietly ignored.
 
-*Partial coverage.* The two ``DogboneAnalytic_MLmask`` lanes are the only ones where a coarse cell is
+*Partial coverage.* The two ``DogboneAnalytic_MLmask`` tests are the only ones where a coarse cell is
 partly land and partly water, which is what the mask-weighted average-down exists for. Producing one
 takes both ``hires_grid_level``, so the coastline is resolved on the refined level rather than injected
 from level 0, and a static refinement box over the coast, since velocity-tagged refinement never covers

--- a/Exec/Generic/inputs_generic
+++ b/Exec/Generic/inputs_generic
@@ -82,7 +82,7 @@ remora.air_pressure = 1013.48
 # type=Real; method=queryAdd
 remora.air_temperature = 23.567
 
-# source: Source/REMORA_DataStruct.H:241
+# source: Source/REMORA_DataStruct.H:246
 # type=bool; method=queryAdd
 remora.atm2ocn_flux_mode = <UNKNOWN_DEFAULT>
 
@@ -102,19 +102,19 @@ remora.bdy_time_varname = <UNKNOWN_DEFAULT>
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_u_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1944
+# source: Source/REMORA.cpp:2331
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_ubar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1943
+# source: Source/REMORA.cpp:2330
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_v_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1945
+# source: Source/REMORA.cpp:2332
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_vbar_time_varname = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1946
+# source: Source/REMORA.cpp:2333
 # type=Vector<std::string>; method=queryAdd
 remora.bdy_zeta_time_varname = <UNKNOWN_DEFAULT>
 
@@ -170,19 +170,23 @@ remora.cfl = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.change_max = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1742
+# source: Source/REMORA.cpp:2129
 # type=string; method=queryAdd
 remora.check_file = chk
 
-# source: Source/REMORA.cpp:1743
+# source: Source/REMORA.cpp:2130
 # type=int; method=queryAdd
 remora.check_int = -57600
 
-# source: Source/REMORA.cpp:1744
+# source: Source/REMORA.cpp:2131
 # type=Real; method=queryAdd
 remora.check_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1849
+# Off by default: the masks are derived from one specification, so this validates that machinery rather than user input. Worth paying for in the test suite and when bringing up a new grid, not in production.
+# type=bool; method=queryAdd
+remora.check_mask_consistency = <UNKNOWN_DEFAULT>
+
+# source: Source/REMORA.cpp:2236
 # type=bool; method=queryAdd
 remora.chunk_history_file = <UNKNOWN_DEFAULT>
 
@@ -222,7 +226,7 @@ remora.coriolis_type = beta_plane
 # type=string; method=queryAdd
 remora.coupling_type = TwoWay
 
-# source: Source/REMORA.cpp:1761
+# source: Source/REMORA.cpp:2148
 # type=Vector<std::string>; method=queryarr
 remora.data_log = <UNKNOWN_DEFAULT>
 
@@ -250,7 +254,7 @@ remora.do_rivers_scalar = <UNKNOWN_DEFAULT>
 # type=bool; method=queryAdd
 remora.do_rivers_temp = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:274
+# source: Source/REMORA_DataStruct.H:279
 # type=bool; method=queryAdd
 remora.eminusp = true
 
@@ -258,7 +262,7 @@ remora.eminusp = true
 # type=bool; method=queryAdd
 remora.eminusp_correct_ssh = true
 
-# source: Source/REMORA_DataStruct.H:270
+# source: Source/REMORA_DataStruct.H:275
 # type=Real; method=query
 remora.eminusp_value = <UNKNOWN_DEFAULT>
 
@@ -266,7 +270,7 @@ remora.eminusp_value = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.eos_type = linear
 
-# source: Source/REMORA.cpp:1745
+# source: Source/REMORA.cpp:2132
 # type=bool; method=queryAdd
 remora.expand_plotvars_to_unif_rr = <UNKNOWN_DEFAULT>
 
@@ -466,7 +470,7 @@ remora.fennel.wPhy = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.fennel.wSDet = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1769
+# source: Source/REMORA.cpp:2156
 # type=int; method=queryAdd
 remora.file_min_digits = 5
 
@@ -498,35 +502,35 @@ remora.gls_N = -1.0
 # type=Real; method=queryAdd
 remora.gls_P = 3.0
 
-# source: Source/REMORA_DataStruct.H:686
+# source: Source/REMORA_DataStruct.H:706
 # type=Real; method=queryAdd
 remora.gls_Pmin = 1.0e-12
 
-# source: Source/REMORA_DataStruct.H:689
+# source: Source/REMORA_DataStruct.H:709
 # type=Real; method=queryAdd
 remora.gls_c1 = 1.44
 
-# source: Source/REMORA_DataStruct.H:690
+# source: Source/REMORA_DataStruct.H:710
 # type=Real; method=queryAdd
 remora.gls_c2 = 1.92
 
-# source: Source/REMORA_DataStruct.H:691
+# source: Source/REMORA_DataStruct.H:711
 # type=Real; method=queryAdd
 remora.gls_c3m = -0.4
 
-# source: Source/REMORA_DataStruct.H:692
+# source: Source/REMORA_DataStruct.H:712
 # type=Real; method=queryAdd
 remora.gls_c3p = 1.0
 
-# source: Source/REMORA_DataStruct.H:688
+# source: Source/REMORA_DataStruct.H:708
 # type=Real; method=queryAdd
 remora.gls_cmu0 = 0.5477
 
-# source: Source/REMORA_DataStruct.H:693
+# source: Source/REMORA_DataStruct.H:713
 # type=Real; method=queryAdd
 remora.gls_sigk = 1.0
 
-# source: Source/REMORA_DataStruct.H:694
+# source: Source/REMORA_DataStruct.H:714
 # type=Real; method=queryAdd
 remora.gls_sigp = 1.3
 
@@ -554,7 +558,7 @@ remora.hires_init_level = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.horizontal_mixing_type = analytic
 
-# source: Source/REMORA_DataStruct.H:435
+# source: Source/REMORA_DataStruct.H:440
 # type=string; method=queryAdd
 remora.ic_bc_type = analytic
 
@@ -562,15 +566,15 @@ remora.ic_bc_type = analytic
 # type=string; method=queryAdd
 remora.ic_type = analytic
 
-# source: Source/REMORA_DataStruct.H:198
+# source: Source/REMORA_DataStruct.H:203
 # type=bool; method=queryAdd
 remora.init_ana_T = true
 
-# source: Source/REMORA_DataStruct.H:200
+# source: Source/REMORA_DataStruct.H:205
 # type=bool; method=queryAdd
 remora.init_l0int_T = false
 
-# source: Source/REMORA_DataStruct.H:196
+# source: Source/REMORA_DataStruct.H:201
 # type=bool; method=queryAdd
 remora.init_l1ad_T = false
 
@@ -594,15 +598,15 @@ remora.longwave_netcdf_varname = <UNKNOWN_DEFAULT>
 # type=Real; method=queryAdd
 remora.longwave_radiation_flux = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:263
+# source: Source/REMORA_DataStruct.H:268
 # type=Real; method=query
 remora.lwrad = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:731
+# source: Source/REMORA_DataStruct.H:751
 # type=Real; method=queryAdd
 remora.m2nudg = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:732
+# source: Source/REMORA_DataStruct.H:752
 # type=Real; method=queryAdd
 remora.m3nudg = <UNKNOWN_DEFAULT>
 
@@ -629,6 +633,10 @@ remora.m_name.particle_box_lo = <UNKNOWN_DEFAULT>
 # We default to placing the particles randomly within each cell, but can override this for regression testing
 # type=bool; method=queryAdd
 remora.m_name.place_randomly_in_cells = true
+
+# that machinery rather than user input. Worth paying for in the test suite and when bringing up a new grid, not in production.
+# type=string; method=queryAdd
+remora.mask_consistency = abort
 
 # If initial condition type is netcdf, default to netcdf masks
 # type=string; method=queryAdd
@@ -674,7 +682,7 @@ remora.nc_river_file = "idRiv_riv_v0.2_classic64.nc"
 # type=int; method=queryAdd
 remora.ndtfast = 0
 
-# source: Source/REMORA.cpp:1747
+# source: Source/REMORA.cpp:2134
 # type=Real; method=query
 remora.netcdf_fill_value = <UNKNOWN_DEFAULT>
 
@@ -682,7 +690,7 @@ remora.netcdf_fill_value = <UNKNOWN_DEFAULT>
 # type=int; method=queryAdd
 remora.nscalar = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA_DataStruct.H:733
+# source: Source/REMORA_DataStruct.H:753
 # type=Real; method=queryAdd
 remora.obcfac = <UNKNOWN_DEFAULT>
 
@@ -694,33 +702,53 @@ remora.omp_tile_size = 8 8 1024000
 # type=bool; method=queryAdd
 remora.output_forcing = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1835
+# source: Source/REMORA.cpp:2222
 # type=string; method=queryAdd
 remora.plot_file = plt
 
-# source: Source/REMORA.cpp:1836
+# source: Source/REMORA.cpp:2223
 # type=int; method=queryAdd
 remora.plot_int = 100
 
-# source: Source/REMORA.cpp:1837
+# source: Source/REMORA.cpp:2224
 # type=Real; method=queryAdd
 remora.plot_int_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1839
+# source: Source/REMORA.cpp:2226
 # type=bool; method=query
 remora.plot_nodal_data = true
 
-# source: Source/REMORA.cpp:1838
+# source: Source/REMORA.cpp:2225
 # type=bool; method=query
 remora.plot_staggered_vels = false
 
-# source: Source/REMORA.cpp:1746
+# source: Source/REMORA.cpp:2133
 # type=Real; method=query
 remora.plotfile_fill_value = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1842
+# source: Source/REMORA.cpp:2229
 # type=string; method=queryAdd
 remora.plotfile_type = amrex
+
+# source: Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H:18
+# type=Real; method=query
+remora.prob.mask_x_hi = <UNKNOWN_DEFAULT>
+
+# source: Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H:17
+# type=Real; method=query
+remora.prob.mask_x_lo = <UNKNOWN_DEFAULT>
+
+# source: Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H:20
+# type=Real; method=query
+remora.prob.mask_y_hi = <UNKNOWN_DEFAULT>
+
+# source: Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H:19
+# type=Real; method=query
+remora.prob.mask_y_lo = <UNKNOWN_DEFAULT>
+
+# Equal to the eastern value leaves temperature uniform, which a test needs if its exact solution is rest.
+# type=Real; method=query
+remora.prob.temp_west = <UNKNOWN_DEFAULT>
 
 # biology active and no dye, Tracer_comp is the first biology component, so testing nComp() would write the dye initial value into NO3.
 # type=bool; method=query
@@ -749,6 +777,10 @@ remora.prob.z0 = 0.1
 # Reference Height
 # type=Real; method=query
 remora.prob.zRef = 80.0e-3
+
+# Off leaves the free surface flat, which a test needs if its exact solution is rest.
+# type=bool; method=query
+remora.prob.zeta_bump = true
 
 # physical
 # type=Vector<Real>; method=queryarr
@@ -830,7 +862,7 @@ remora.refinement_indicators_.value_greater = <REQUIRED>
 # type=Real; method=getarr
 remora.refinement_indicators_.value_less = <REQUIRED>
 
-# source: Source/REMORA.cpp:1748
+# source: Source/REMORA.cpp:2135
 # type=string; method=queryAdd
 remora.restart = <UNKNOWN_DEFAULT>
 
@@ -854,7 +886,7 @@ remora.smflux_type = analytic
 # type=Real; method=queryAdd
 remora.start_time = <UNKNOWN_DEFAULT>
 
-# source: Source/REMORA.cpp:1850
+# source: Source/REMORA.cpp:2237
 # type=int; method=queryAdd
 remora.steps_per_history_file = <UNKNOWN_DEFAULT>
 
@@ -866,7 +898,7 @@ remora.stop_time = 30000.0
 # type=int; method=queryAdd
 remora.sum_interval = -1
 
-# source: Source/REMORA.cpp:1768
+# source: Source/REMORA.cpp:2155
 # type=Real; method=queryAdd
 remora.sum_period = <UNKNOWN_DEFAULT>
 
@@ -966,11 +998,11 @@ remora.vwind = <UNKNOWN_DEFAULT>
 # type=string; method=queryAdd
 remora.wind_type = analytic
 
-# source: Source/REMORA.cpp:1848
+# source: Source/REMORA.cpp:2235
 # type=bool; method=queryAdd
 remora.write_history_file = true
 
-# source: Source/REMORA_DataStruct.H:730
+# source: Source/REMORA_DataStruct.H:750
 # type=Real; method=queryAdd
 remora.znudg = <UNKNOWN_DEFAULT>
 
@@ -1405,7 +1437,7 @@ vismf.v = <UNKNOWN_DEFAULT>
 # type=bool; method=queryAdd
 amrex.abort_on_out_of_gpu_memory = false
 
-# source: Src/Base/AMReX.cpp:574
+# source: Src/Base/AMReX.cpp:575
 # type=unknown; method=queryAdd
 amrex.abort_on_unused_inputs = <UNKNOWN_DEFAULT>
 
@@ -1417,7 +1449,7 @@ amrex.async_out = false
 # type=int; method=queryAdd
 amrex.async_out_nfiles = 64
 
-# source: Src/Base/AMReX.cpp:573
+# source: Src/Base/AMReX.cpp:574
 # type=unknown; method=query
 amrex.call_addr2line = <UNKNOWN_DEFAULT>
 
@@ -1437,43 +1469,43 @@ amrex.fpe_trap_overflow = false
 # type=unknown; method=queryAdd
 amrex.fpe_trap_zero = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:590
+# source: Src/Base/AMReX.cpp:591
 # type=unknown; method=queryAdd
 amrex.handle_sigabrt = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:591
+# source: Src/Base/AMReX.cpp:592
 # type=unknown; method=queryAdd
 amrex.handle_sigfpe = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:592
+# source: Src/Base/AMReX.cpp:593
 # type=unknown; method=queryAdd
 amrex.handle_sigill = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:589
+# source: Src/Base/AMReX.cpp:590
 # type=unknown; method=queryAdd
 amrex.handle_sigint = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:587
+# source: Src/Base/AMReX.cpp:588
 # type=unknown; method=queryAdd
 amrex.handle_sigsegv = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:588
+# source: Src/Base/AMReX.cpp:589
 # type=unknown; method=queryAdd
 amrex.handle_sigterm = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:683
+# source: Src/Base/AMReX.cpp:684
 # type=bool; method=queryAdd
 amrex.hypre_spgemm_use_vendor = false
 
-# source: Src/Base/AMReX.cpp:684
+# source: Src/Base/AMReX.cpp:685
 # type=bool; method=queryAdd
 amrex.hypre_spmv_use_vendor = false
 
-# source: Src/Base/AMReX.cpp:685
+# source: Src/Base/AMReX.cpp:686
 # type=bool; method=queryAdd
 amrex.hypre_sptrans_use_vendor = false
 
-# source: Src/Base/AMReX.cpp:681
+# source: Src/Base/AMReX.cpp:682
 # type=bool; method=queryAdd
 amrex.init_hypre = true
 
@@ -1505,19 +1537,19 @@ amrex.parmparse.v = <UNKNOWN_DEFAULT>
 # type=int; method=queryAdd
 amrex.pout_int = 1
 
-# source: Src/Base/AMReX.cpp:570
+# source: Src/Base/AMReX.cpp:571
 # type=unknown; method=query
 amrex.regtest_reduction = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:571
+# source: Src/Base/AMReX.cpp:572
 # type=unknown; method=queryAdd
 amrex.signal_handling = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX_ParallelDescriptor.cpp:1610
+# source: Src/Base/AMReX_ParallelDescriptor.cpp:1612
 # type=int; method=query
 amrex.team.reduce = 0
 
-# source: Src/Base/AMReX_ParallelDescriptor.cpp:1609
+# source: Src/Base/AMReX_ParallelDescriptor.cpp:1611
 # type=int; method=query
 amrex.team.size = 1
 
@@ -1585,11 +1617,11 @@ amrex.the_pinned_arena_init_size = 0
 # type=Long; method=queryAdd
 amrex.the_pinned_arena_release_threshold = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX.cpp:572
+# source: Src/Base/AMReX.cpp:573
 # type=unknown; method=queryAdd
 amrex.throw_exception = <UNKNOWN_DEFAULT>
 
-# source: Src/Base/AMReX_ParallelDescriptor.cpp:1583
+# source: Src/Base/AMReX_ParallelDescriptor.cpp:1585
 # type=bool; method=queryAdd
 amrex.use_gpu_aware_mpi = false
 
@@ -1682,7 +1714,7 @@ device.v = 0
 #==============================================================================
 # TINY PROFILER PARAMETERS
 #==============================================================================
-# source: Src/Base/AMReX_TinyProfiler.cpp:324
+# source: Src/Base/AMReX_TinyProfiler.cpp:353
 # type=bool; method=queryAdd
 tiny_profiler.device_synchronize_around_region = false
 
@@ -1690,13 +1722,13 @@ tiny_profiler.device_synchronize_around_region = false
 # type=bool; method=queryAdd
 tiny_profiler.enabled = true
 
-# source: Src/Base/AMReX_TinyProfiler.cpp:355
+# source: Src/Base/AMReX_TinyProfiler.cpp:384
 # type=bool; method=queryAdd
 tiny_profiler.memprof_enabled = true
 
 # the timer and memory reports (both opened in append mode) coexist.
 # type=return; method=query
-tiny_profiler.output_file = <UNKNOWN_DEFAULT>
+tiny_profiler.output_file = stdout
 
 # Specify the maximum percentage of inclusive time that the "Other" section in the output can have (default 1%)
 # type=Real; method=queryAdd
@@ -1812,36 +1844,36 @@ blprofiler.prof_traceflushsize = <UNKNOWN_DEFAULT>
 #==============================================================================
 # DRIVER PARAMETERS
 #==============================================================================
-# source: Source/REMORA_DataStruct.H:245
+# source: Source/REMORA_DataStruct.H:250
 # type=string; method=query
 driver.atm2ocn_mode = state
 
 #==============================================================================
 # NUMBLOCKS PARAMETERS
 #==============================================================================
-# source: Src/Base/AMReX_GpuDevice.cpp:662
+# source: Src/Base/AMReX_GpuDevice.cpp:667
 # type=int; method=query
 numBlocks.x = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:663
+# source: Src/Base/AMReX_GpuDevice.cpp:668
 # type=int; method=query
 numBlocks.y = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:664
+# source: Src/Base/AMReX_GpuDevice.cpp:669
 # type=int; method=query
 numBlocks.z = 0
 
 #==============================================================================
 # NUMTHREADS PARAMETERS
 #==============================================================================
-# source: Src/Base/AMReX_GpuDevice.cpp:650
+# source: Src/Base/AMReX_GpuDevice.cpp:655
 # type=int; method=query
 numThreads.x = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:651
+# source: Src/Base/AMReX_GpuDevice.cpp:656
 # type=int; method=query
 numThreads.y = 0
 
-# source: Src/Base/AMReX_GpuDevice.cpp:652
+# source: Src/Base/AMReX_GpuDevice.cpp:657
 # type=int; method=query
 numThreads.z = 0

--- a/Exec/IdealMiniGrid/inputs_synth_hires
+++ b/Exec/IdealMiniGrid/inputs_synth_hires
@@ -10,7 +10,7 @@
 #
 # With both hires levels set and coriolis off, the level-0 NetCDF files are never dereferenced:
 # bathymetry, metrics, mask, state and zeta all arrive by coarsening down from level 1. So this
-# lane needs only the two hires files.
+# case needs only the two hires files.
 
 remora.prob_name = IdealMiniGrid
 
@@ -49,9 +49,9 @@ remora.nc_init_file_hires = "hires_ini.nc"
 remora.hires_grid_level   = 1
 remora.hires_init_level   = 1
 
-# Coriolis would want `f` from a level-0 grid file, which this lane does not have, so it stays
+# Coriolis would want `f` from a level-0 grid file, which this case does not have, so it stays
 # off. The mask no longer needs one: hires_grd.nc carries mask_rho, and a level at or below
-# hires_grid_level takes the mask coarsened down from it. Left off here so this lane covers the
+# hires_grid_level takes the mask coarsened down from it. Left off here so this case covers the
 # unmasked path; override with remora.mask_type = netcdf to exercise the mask weighting, and see
 # the VOLUME note below for what that should give.
 remora.mask_type    = "none"

--- a/Exec/IdealMiniGrid/inputs_synth_hires
+++ b/Exec/IdealMiniGrid/inputs_synth_hires
@@ -8,9 +8,9 @@
 #
 #   python3 ../../Tests/tools/make_hires_test_data.py --dir . --n-cell 10 10 4 --ref-ratio 3
 #
-# With both hires levels set, and with coriolis and masks off, the level-0 NetCDF files are never
-# dereferenced: bathymetry, metrics, state and zeta all arrive by averaging down from level 1. So
-# this lane needs only the two hires files.
+# With both hires levels set and coriolis off, the level-0 NetCDF files are never dereferenced:
+# bathymetry, metrics, mask, state and zeta all arrive by coarsening down from level 1. So this
+# lane needs only the two hires files.
 
 remora.prob_name = IdealMiniGrid
 
@@ -49,15 +49,29 @@ remora.nc_init_file_hires = "hires_ini.nc"
 remora.hires_grid_level   = 1
 remora.hires_init_level   = 1
 
-# Masks default to netcdf when ic_type is netcdf, and coriolis would want `f` from a level-0
-# grid file. Turning both off is what lets this lane run on the two hires files alone.
+# Coriolis would want `f` from a level-0 grid file, which this lane does not have, so it stays
+# off. The mask no longer needs one: hires_grd.nc carries mask_rho, and a level at or below
+# hires_grid_level takes the mask coarsened down from it. Left off here so this lane covers the
+# unmasked path; override with remora.mask_type = netcdf to exercise the mask weighting, and see
+# the VOLUME note below for what that should give.
 remora.mask_type    = "none"
 remora.use_coriolis = false
 
+# Inert while mask_type = none, and worth having on whenever it is not: validates that the mask
+# on each level agrees with the one above it, which is what the mask-weighted coarsening assumes.
+remora.check_mask_consistency = true
+
 # DIAGNOSTICS & VERBOSITY
 # sum_precision = 15 so VOLUME can be compared against a reference rather than just eyeballed:
-# at t = 0, sum_k Hz == zeta + h exactly, so VOLUME is a direct readout of the averaged-down
-# bathymetry and metrics. Compare it against sum h/(pm*pn) over the hires file's interior.
+# at t = 0, sum_k Hz == zeta + h exactly, so VOLUME is a direct readout of the coarsened
+# bathymetry and metrics. volWgtSumMF does not mask, so it reads out the mask weighting too:
+#
+#   mask_type = none      VOLUME(t=0) = 9522606688.290653
+#   mask_type = netcdf    VOLUME(t=0) = 9506731758.713726
+#
+# Both follow from the two NetCDF files alone: block mean of pm and pn divided by the refinement
+# ratio, and for h and zeta either the plain block mean or the mean over the block's wet cells.
+# At n_cell = 10 10 4 and ratio 3 the coastline leaves 10 coarse cells partly wet and 20 dry.
 remora.v             = 1
 remora.sum_interval  = 1
 remora.sum_precision = 15
@@ -66,7 +80,7 @@ remora.sum_precision = 15
 remora.plot_file     = plt
 remora.plot_int      = 10
 remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
-remora.plot_vars_2d  = h
+remora.plot_vars_2d  = h mask_rho
 remora.plotfile_type = amrex
 
 # SOLVER CHOICE

--- a/Exec/REMORA_Prob.H
+++ b/Exec/REMORA_Prob.H
@@ -50,9 +50,9 @@ public:
 
     void init_analytic_masks(
         int lev,
-        const amrex::Geometry& /*geom*/,
+        const amrex::Geometry& geom,
         SolverChoice const& /*m_solverChoice*/,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_mskr) override;
 
     void init_analytic_smflux(

--- a/Exec/REMORA_Prob.cpp
+++ b/Exec/REMORA_Prob.cpp
@@ -341,10 +341,10 @@ void Problem::init_analytic_grid_scale (
 }
 
 void Problem::init_analytic_masks(
-        int lev,
-        const amrex::Geometry& /*geom*/,
+        int /*lev*/,
+        const amrex::Geometry& geom,
         SolverChoice const& /*m_solverChoice*/,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         MultiFab& mf_mskr)
 {
     ParmParse pp("remora");

--- a/Source/IO/REMORA_ReadFromInitNetcdf.cpp
+++ b/Source/IO/REMORA_ReadFromInitNetcdf.cpp
@@ -575,16 +575,16 @@ read_coriolis_from_netcdf (int /*lev*/,
  * @param domain          simulation domain
  * @param fname           file name to read from
  * @param NC_mskr_fab     container for rho-point land/sea mask data
- * @param NC_msku_fab     container for u-point land/sea mask data
- * @param NC_mskv_fab     container for v-point land/sea mask data
+ *
+ * Only mask_rho is read. The u-, v- and psi-point masks are derived from it as ROMS
+ * set_masks.F defines them, so a file whose staggered masks disagree with its mask_rho cannot
+ * put the two out of step.
  */
 void
 read_masks_from_netcdf (int /*lev*/,
                         const Box& domain,
                         const std::string& fname,
-                        FArrayBox& NC_mskr_fab,
-                        FArrayBox& NC_msku_fab,
-                        FArrayBox& NC_mskv_fab)
+                        FArrayBox& NC_mskr_fab)
 {
     amrex::Print() << "Loading masks from NetCDF file " << fname << std::endl;
 
@@ -593,8 +593,6 @@ read_masks_from_netcdf (int /*lev*/,
     Vector<enum NC_Data_Dims_Type> NC_dim_types;
 
     NC_fabs.push_back(&NC_mskr_fab )   ; NC_names.push_back("mask_rho")  ; NC_dim_types.push_back(NC_Data_Dims_Type::SN_WE); // 0
-    NC_fabs.push_back(&NC_msku_fab )   ; NC_names.push_back("mask_u")    ; NC_dim_types.push_back(NC_Data_Dims_Type::SN_WE); // 1
-    NC_fabs.push_back(&NC_mskv_fab )   ; NC_names.push_back("mask_v")    ; NC_dim_types.push_back(NC_Data_Dims_Type::SN_WE); // 2
 
     // Read the netcdf file and fill these FABs
     BuildFABsFromNetCDFFile<FArrayBox,Real>(domain, fname, NC_names, NC_dim_types, NC_fabs);

--- a/Source/IO/REMORA_ReadFromInitNetcdf.cpp
+++ b/Source/IO/REMORA_ReadFromInitNetcdf.cpp
@@ -494,6 +494,33 @@ read_bathymetry_full_domain_from_netcdf (const Box& domain,
 }
 
 /**
+ * @param domain          simulation domain at nc_hires_grid_level
+ * @param fname           file name to read from
+ * @param NC_mskr_fab     container for rho-point land/sea mask data
+ * @param ngrow           number of grow cells to read in, if not default
+ *
+ * Only mask_rho is read. The u-, v- and psi-point masks are derived from it, the way ROMS
+ * set_masks.F defines them, rather than read independently -- which also means a coarsened
+ * level's staggered masks stay consistent with its rho-mask.
+ */
+void
+read_masks_full_domain_from_netcdf (const Box& domain,
+                                    const std::string& fname,
+                                    FArrayBox& NC_mskr_fab, IntVect ngrow)
+{
+    amrex::Print() << "Loading high resolution land/sea mask from NetCDF file " << fname << std::endl;
+
+    Vector<FArrayBox*> NC_fabs;
+    Vector<std::string> NC_names;
+    Vector<enum NC_Data_Dims_Type> NC_dim_types;
+
+    NC_fabs.push_back(&NC_mskr_fab) ; NC_names.push_back("mask_rho") ; NC_dim_types.push_back(NC_Data_Dims_Type::SN_WE); // 0
+
+    // Read the netcdf file and fill these FABs
+    BuildFABsFromNetCDFFile<FArrayBox,Real>(domain, fname, NC_names, NC_dim_types, NC_fabs, false, 0, ngrow);
+}
+
+/**
  * @param lev             level of data to read
  * @param domain          simulation domain
  * @param fname           file name to read from

--- a/Source/Initialization/REMORA_init.cpp
+++ b/Source/Initialization/REMORA_init.cpp
@@ -363,10 +363,10 @@ REMORA::init_bathymetry_full_domain_from_analytic ()
 {
     // init_analytic_bathymetry needs to be able to handle the full number of grow cells that vec_h_full_domain has
     prob->init_analytic_bathymetry(hires_grid_level, Geom(hires_grid_level), solverChoice, *this, *vec_h_full_domain[hires_grid_level]);
-    // Average down to fill levels below hires_grid_level. Use a special average_down so grow cells
-    // get populated by averaged down fine data
+    // Coarsen to fill levels below hires_grid_level, grow cells included. Mask-weighted, so a
+    // coarse cell only partly covered by water takes the depth of that water.
     for (int lev=hires_grid_level-1; lev >= 0; lev--) {
-        average_down_with_grow_cells(lev, vec_h_full_domain);
+        coarsen_bathymetry_with_grow_cells(lev);
     }
 }
 

--- a/Source/Initialization/REMORA_init.cpp
+++ b/Source/Initialization/REMORA_init.cpp
@@ -101,7 +101,7 @@ REMORA::init_biology_ic_full_domain ()
     // nothing else, so every level below it -- including level 0, the one the run actually
     // integrates -- kept the zeros that init_data_full_domain_from_netcdf had written.
     for (int lev = hires_init_level-1; lev >= 0; lev--) {
-        average_down_with_grow_cells(lev, vec_cons_full_domain);
+        average_down_with_grow_cells(lev, vec_cons_full_domain, true);
     }
 }
 
@@ -438,9 +438,9 @@ REMORA::init_full_domain_from_analytic ()
     init_biology_ic_full_domain();
 
     for (int lev=hires_init_level-1; lev >= 0; lev--) {
-        average_down_with_grow_cells(lev, vec_cons_full_domain);
-        average_down_with_grow_cells(lev, vec_xvel_full_domain);
-        average_down_with_grow_cells(lev, vec_yvel_full_domain);
+        average_down_with_grow_cells(lev, vec_cons_full_domain, true);
+        average_down_with_grow_cells(lev, vec_xvel_full_domain, true);
+        average_down_with_grow_cells(lev, vec_yvel_full_domain, true);
     }
 }
 
@@ -450,6 +450,6 @@ REMORA::init_full_domain_zeta_from_analytic ()
     prob->init_analytic_zeta(hires_init_level, geom[hires_init_level], solverChoice, *this, *vec_zeta_full_domain[hires_init_level]);
 
     for (int lev=hires_init_level-1; lev >= 0; lev--) {
-        average_down_with_grow_cells(lev, vec_zeta_full_domain);
+        average_down_with_grow_cells(lev, vec_zeta_full_domain, true);
     }
 }

--- a/Source/Initialization/REMORA_init.cpp
+++ b/Source/Initialization/REMORA_init.cpp
@@ -327,10 +327,12 @@ void REMORA::allocate_bathymetry_grid_vars_full_domain () {
     vec_h_full_domain[0].reset(new MultiFab(ba, dm, 1, IntVect(1,1,0)));
     vec_pm_full_domain[0].reset(new MultiFab(ba, dm, 1, IntVect(1,1,0)));
     vec_pn_full_domain[0].reset(new MultiFab(ba, dm, 1, IntVect(1,1,0)));
+    vec_mskr_full_domain[0].reset(new MultiFab(ba, dm, 1, IntVect(1,1,0)));
 
     auto h_growvect = vec_h[0]->nGrowVect();
     auto pm_growvect = vec_pm[0]->nGrowVect();
     auto pn_growvect = vec_pn[0]->nGrowVect();
+    auto mskr_growvect = vec_mskr[0]->nGrowVect();
     for (int lev=1; lev <= hires_grid_level; lev++) {
         ba = ba.refine(refRatio(lev-1));
         refined_domain.refine(refRatio(lev-1));
@@ -340,6 +342,7 @@ void REMORA::allocate_bathymetry_grid_vars_full_domain () {
         vec_h_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratios[lev],h_growvect)));
         vec_pm_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratios[lev],pm_growvect)));
         vec_pn_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratios[lev],pn_growvect)));
+        vec_mskr_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratios[lev],mskr_growvect)));
     }
     // A NetCDF read covers only as many grow cells as the file carries, and the analytic
     // bathymetry hook fills h alone, so parts of these arrays can reach the average-down
@@ -348,6 +351,9 @@ void REMORA::allocate_bathymetry_grid_vars_full_domain () {
         vec_h_full_domain[lev]->setVal(0.0);
         vec_pm_full_domain[lev]->setVal(0.0);
         vec_pn_full_domain[lev]->setVal(0.0);
+        // Water, not zero: the mask readers and the analytic hook only ever write land, so
+        // anything they miss has to default the way the per-level masks do in init_masks.
+        vec_mskr_full_domain[lev]->setVal(1.0);
     }
     nc_hires_grid_box = refined_domain;
 }
@@ -361,6 +367,21 @@ REMORA::init_bathymetry_full_domain_from_analytic ()
     // get populated by averaged down fine data
     for (int lev=hires_grid_level-1; lev >= 0; lev--) {
         average_down_with_grow_cells(lev, vec_h_full_domain);
+    }
+}
+
+void
+REMORA::init_masks_full_domain_from_analytic ()
+{
+    // init_analytic_masks has to be able to handle the full number of grow cells that
+    // vec_mskr_full_domain has, and cannot reach for the per-level coordinate arrays, since
+    // this MultiFab is not on grids[hires_grid_level].
+    prob->init_analytic_masks(hires_grid_level, Geom(hires_grid_level), solverChoice, *this,
+                              *vec_mskr_full_domain[hires_grid_level]);
+    // Coarsen to fill the levels below hires_grid_level. Not average_down_with_grow_cells:
+    // a mask has to stay exactly 0 or 1, so this takes "wet if any fine cell is wet".
+    for (int lev=hires_grid_level-1; lev >= 0; lev--) {
+        coarsen_masks_with_grow_cells(lev);
     }
 }
 

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -785,6 +785,7 @@ REMORA::init_masks_from_netcdf (int lev)
         } // omp
     } // idx
 
+    verify_file_nodal_masks(lev);
     update_mskp(lev);
     vec_mskr[lev]->FillBoundary(geom[lev].periodicity());
     vec_msku[lev]->FillBoundary(geom[lev].periodicity());

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -348,9 +348,9 @@ REMORA::init_data_full_domain_from_netcdf ()
     // Average down to fill levels below hires_grid_level. Use a special average_down so
     // grow cells get populated by averaged down fine data
     for (int lev=hires_init_level-1; lev >= 0; lev--) {
-        average_down_with_grow_cells(lev, vec_cons_full_domain);
-        average_down_with_grow_cells(lev, vec_xvel_full_domain);
-        average_down_with_grow_cells(lev, vec_yvel_full_domain);
+        average_down_with_grow_cells(lev, vec_cons_full_domain, true);
+        average_down_with_grow_cells(lev, vec_xvel_full_domain, true);
+        average_down_with_grow_cells(lev, vec_yvel_full_domain, true);
     }
 }
 
@@ -519,7 +519,7 @@ REMORA::init_zeta_full_domain_from_netcdf ()
     // Average down to fill levels below hires_grid_level. Use a special average_down so
     // grow cells get populated by averaged down fine data
     for (int lev=hires_init_level-1; lev >= 0; lev--) {
-        average_down_with_grow_cells(lev, vec_zeta_full_domain);
+        average_down_with_grow_cells(lev, vec_zeta_full_domain, true);
     }
 }
 

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -55,11 +55,10 @@ void
 check_hires_dims_from_netcdf (const std::string& fname, const std::string& var_name,
                               const Box& domain, const IntVect& ngrow);
 
-/** \brief helper function for reading in land-sea masks from netcdf */
+/** \brief helper function for reading in the rho-point land-sea mask from netcdf */
 void
 read_masks_from_netcdf (int /*lev*/, const Box& domain, const std::string& fname,
-                       FArrayBox& NC_mskr_fab, FArrayBox& NC_msku_fab,
-                       FArrayBox& NC_mskv_fab);
+                       FArrayBox& NC_mskr_fab);
 
 /** \brief helper function to initialize state from netcdf */
 void
@@ -753,14 +752,11 @@ REMORA::init_masks_from_netcdf (int lev)
 {
     // *** FArrayBox's at this level for holding the INITIAL data
     Vector<FArrayBox> NC_mskr_fab     ; NC_mskr_fab.resize(num_boxes_at_level[lev]);
-    Vector<FArrayBox> NC_msku_fab     ; NC_msku_fab.resize(num_boxes_at_level[lev]);
-    Vector<FArrayBox> NC_mskv_fab     ; NC_mskv_fab.resize(num_boxes_at_level[lev]);
 
     for (int idx = 0; idx < num_boxes_at_level[lev]; idx++)
     {
         read_masks_from_netcdf(lev,boxes_at_level[lev][idx], nc_grid_file[lev][idx],
-                                    NC_mskr_fab[idx],NC_msku_fab[idx],
-                                    NC_mskv_fab[idx]);
+                                    NC_mskr_fab[idx]);
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -770,8 +766,6 @@ REMORA::init_masks_from_netcdf (int lev)
         for ( MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi )
         {
             FArrayBox &mskr_fab  = (*vec_mskr[lev])[mfi];
-            FArrayBox &msku_fab  = (*vec_msku[lev])[mfi];
-            FArrayBox &mskv_fab  = (*vec_mskv[lev])[mfi];
 
             //
             // FArrayBox to FArrayBox copy does "copy on intersection"
@@ -779,18 +773,13 @@ REMORA::init_masks_from_netcdf (int lev)
             //
 
             mskr_fab.template    copy<RunOn::Device>(NC_mskr_fab[idx]);
-            msku_fab.template    copy<RunOn::Device>(NC_msku_fab[idx]);
-            mskv_fab.template    copy<RunOn::Device>(NC_mskv_fab[idx]);
         } // mf
         } // omp
     } // idx
 
-    verify_file_nodal_masks(lev);
-    update_mskp(lev);
+    // Ghosts first: update_nodal_masks reaches mskr(i-1,j-1).
     vec_mskr[lev]->FillBoundary(geom[lev].periodicity());
-    vec_msku[lev]->FillBoundary(geom[lev].periodicity());
-    vec_mskv[lev]->FillBoundary(geom[lev].periodicity());
-    vec_mskp[lev]->FillBoundary(geom[lev].periodicity());
+    update_nodal_masks(lev);
 }
 
 /**

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -1141,10 +1141,10 @@ REMORA::init_bathymetry_full_domain_from_netcdf ()
         h_fab.template    copy<RunOn::Device>(NC_h_fab[0]);
     }
 
-    // Average down to fill levels below hires_grid_level. Use a special average_down so
-    // grow cells get populated by averaged down fine data
+    // Coarsen to fill levels below hires_grid_level, grow cells included. Mask-weighted, so a
+    // coarse cell only partly covered by water takes the depth of that water.
     for (int lev=hires_grid_level-1; lev >= 0; lev--) {
-        average_down_with_grow_cells(lev, vec_h_full_domain);;
+        coarsen_bathymetry_with_grow_cells(lev);
     }
 }
 

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -112,6 +112,11 @@ read_grid_vars_full_domain_from_netcdf (const Box& domain, const std::string& fn
                                          FArrayBox& NC_pm_fab, FArrayBox& NC_pn_fab,
                                          IntVect ngrow);
 
+/** \brief helper function to read full-domain high resolution land/sea mask from netcdf */
+void
+read_masks_full_domain_from_netcdf (const Box& domain, const std::string& fname,
+                                    FArrayBox& NC_mskr_fab, IntVect ngrow);
+
 /** \brief helper function to read coriolis factor from netcdf */
 void
 read_coriolis_from_netcdf (int lev, const Box& domain, const std::string& fname, FArrayBox& NC_fcor_fab);
@@ -1139,6 +1144,33 @@ REMORA::init_bathymetry_full_domain_from_netcdf ()
     // grow cells get populated by averaged down fine data
     for (int lev=hires_grid_level-1; lev >= 0; lev--) {
         average_down_with_grow_cells(lev, vec_h_full_domain);;
+    }
+}
+
+void
+REMORA::init_masks_full_domain_from_netcdf ()
+{
+    if (nc_grid_file_hires.empty()) {
+        Abort("Must specify high-resolution grid file when remora.mask_type = netcdf and hires_grid_level > 0");
+    }
+    check_hires_dims_from_netcdf(nc_grid_file_hires, "mask_rho", nc_hires_grid_box,
+                                 cum_ref_ratios[hires_grid_level]);
+
+    Vector<FArrayBox> NC_mskr_fab   ; NC_mskr_fab.resize(1);
+    read_masks_full_domain_from_netcdf(nc_hires_grid_box, nc_grid_file_hires, NC_mskr_fab[0],
+                                       cum_ref_ratios[hires_grid_level]);
+
+    // Don't tile this since we are operating on full FABs in this routine
+    for ( MFIter mfi(*vec_mskr_full_domain[hires_grid_level], false); mfi.isValid(); ++mfi )
+    {
+        FArrayBox &mskr_fab  = (*vec_mskr_full_domain[hires_grid_level])[mfi];
+        mskr_fab.template    copy<RunOn::Device>(NC_mskr_fab[0]);
+    }
+
+    // Coarsen to fill the levels below hires_grid_level. Not average_down_with_grow_cells:
+    // a mask has to stay exactly 0 or 1, so this takes "wet if any fine cell is wet".
+    for (int lev=hires_grid_level-1; lev >= 0; lev--) {
+        coarsen_masks_with_grow_cells(lev);
     }
 }
 

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -1052,7 +1052,7 @@ REMORA::calculate_nodal_masks (int lev)
 /**
  * Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghost cells.
  *
- * Every lane goes through here, so the levels cannot end up with different definitions.
+ * Every path goes through here, so the levels cannot end up with different definitions.
  *
  * @param[in   ] lev    level to operate on
  */

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -85,6 +85,12 @@ REMORA::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     vec_vbar[lev]->setVal(zero);
 
 
+    // Before the fills: FillPatch masks domain-boundary ghosts through physbcs, so these must
+    // hold the real coastline rather than init_masks' all-water placeholder. Order matters:
+    // init_stuff reallocates the coordinates set_grid_scale fills, which set_masks may read.
+    set_grid_scale(lev);
+    set_masks(lev);
+
     FillCoarsePatch(lev, time, cons_new[lev], cons_new[lev-1],BCVars::Temp_bc_comp,BdyVars::t);
     FillCoarsePatch(lev, time, xvel_new[lev], xvel_new[lev-1], xvel_bc(), BdyVars::u);
     FillCoarsePatch(lev, time, yvel_new[lev], yvel_new[lev-1], yvel_bc(), BdyVars::v);
@@ -117,11 +123,6 @@ REMORA::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
                 BdyVars::null,icomp,false);
     }
 
-    set_grid_scale(lev);
-    // After set_grid_scale: an analytic mask reads the grid coordinates it fills. This picks
-    // the same lane level 0 uses, so a level at or below hires_grid_level takes the
-    // high-resolution mask instead of an injection from the coarser level.
-    set_masks(lev);
     stretch_transform(lev);
 
     init_set_vmix(lev);
@@ -235,6 +236,11 @@ REMORA::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionM
     tmp_vbar_new.setVal(zero);
 
 
+    // As in MakeNewLevelFromCoarse. init_stuff comes along because set_grid_scale follows it.
+    init_stuff(lev, ba, dm);
+    set_grid_scale(lev);
+    set_masks(lev);
+
     // This will fill the temporary MultiFabs with data from previous fine data as well as coarse where needed
     FillPatch(lev, time, tmp_cons_new, cons_new, BCVars::cons_bc, BdyVars::t,0,true,false);
     FillPatch(lev, time, tmp_xvel_new, xvel_new, xvel_bc(), BdyVars::u,0,true,false,0,0,zero,tmp_xvel_new);
@@ -294,13 +300,6 @@ REMORA::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionM
     t_new[lev] = time;
     t_old[lev] = time - bogus_large_value;
 
-    init_stuff(lev, ba, dm);
-
-    set_grid_scale(lev);
-    // See MakeNewLevelFromCoarse. The init_masks call further up already allocated the masks
-    // on the new BoxArray -- set_bathymetry_averaged_down needs them there -- so this only
-    // has to fill them.
-    set_masks(lev);
     stretch_transform(lev);
 
     init_set_vmix(lev);

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -482,6 +482,11 @@ void REMORA::resize_stuff(int lev)
     vec_mskv.resize(lev+1);
     vec_mskp.resize(lev+1);
     vec_mskr3d.resize(lev+1);
+    // Indexed by the coarse level of a pair, so lev entries would do; sized like the rest to
+    // keep the indexing uniform.
+    vec_mskr_crse_on_fine.resize(lev+1);
+    vec_msku_crse_on_fine.resize(lev+1);
+    vec_mskv_crse_on_fine.resize(lev+1);
     vec_sstore.resize(lev+1);
 
     vec_cons_full_domain.resize(hires_init_level+1);

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -979,50 +979,6 @@ REMORA::set_zeta_to_Ztavg (int lev, bool apply_eminusp)
     }
 }
 
-/**
- * @param[in   ] lev    level to operate on
- */
-void
-REMORA::update_mskp (int lev)
-{
-    for ( MFIter mfi(*vec_mskr[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
-    {
-        Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);
-        Array4<      Real> const& mskp = vec_mskp[lev]->array(mfi);
-
-        // NGROW rings, not one: the stencil reaches mskr(i-1,j-1), and mskr carries NGROW+1.
-        Box bx = mfi.tilebox(); bx.grow(IntVect(NGROW,NGROW,0)); bx.makeSlab(2,0);
-
-        Real cff1 = one;
-        Real cff2 = two;
-
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int)
-        {
-            if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
-                mskp(i,j,0) = one;
-            } else if ((mskr(i-1,j,0) < Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
-                mskp(i,j,0) = cff1;
-            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) < Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
-                mskp(i,j,0) = cff1;
-            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) < Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
-                mskp(i,j,0) = cff1;
-            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) < Real(0.5))) {
-                mskp(i,j,0) = cff1;
-            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) < Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) < Real(0.5))) {
-                mskp(i,j,0) = cff2;
-            } else if ((mskr(i-1,j,0) < Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) < Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
-                mskp(i,j,0) = cff2;
-            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) < Real(0.5)) and (mskr(i,j-1,0) < Real(0.5))) {
-                mskp(i,j,0) = cff2;
-            } else if ((mskr(i-1,j,0) < Real(0.5)) and (mskr(i,j,0) < Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
-                mskp(i,j,0) = cff2;
-            } else {
-                mskp(i,j,0) = zero;
-            }
-
-        });
-    }
-}
 
 /**
  * @param[in   ] lev    level to operate on
@@ -1044,7 +1000,28 @@ REMORA::calculate_nodal_masks (int lev)
         {
             msku(i,j,0) = mskr(i-1,j  ,0) * mskr(i,j,0);
             mskv(i,j,0) = mskr(i  ,j-1,0) * mskr(i,j,0);
-            mskp(i,j,0) = mskr(i-1,j-1,0) * mskr(i,j,0) * mskr(i-1,j,0) * mskr(i,j-1,0);
+            // mskp is 2 along a straight land-sea boundary
+            if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
+                mskp(i,j,0) = one;
+            } else if ((mskr(i-1,j,0) < Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
+                mskp(i,j,0) = one;
+            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) < Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
+                mskp(i,j,0) = one;
+            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) < Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
+                mskp(i,j,0) = one;
+            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) < Real(0.5))) {
+                mskp(i,j,0) = one;
+            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) < Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) < Real(0.5))) {
+                mskp(i,j,0) = two;
+            } else if ((mskr(i-1,j,0) < Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) < Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
+                mskp(i,j,0) = two;
+            } else if ((mskr(i-1,j,0) > Real(0.5)) and (mskr(i,j,0) > Real(0.5)) and (mskr(i-1,j-1,0) < Real(0.5)) and (mskr(i,j-1,0) < Real(0.5))) {
+                mskp(i,j,0) = two;
+            } else if ((mskr(i-1,j,0) < Real(0.5)) and (mskr(i,j,0) < Real(0.5)) and (mskr(i-1,j-1,0) > Real(0.5)) and (mskr(i,j-1,0) > Real(0.5))) {
+                mskp(i,j,0) = two;
+            } else {
+                mskp(i,j,0) = zero;
+            }
         });
     }
 }
@@ -1060,12 +1037,7 @@ void
 REMORA::update_nodal_masks (int lev)
 {
     calculate_nodal_masks(lev);
-    // The psi mask has two definitions: the plain product calculate_nodal_masks just wrote,
-    // and ROMS set_masks.F's rule, which also yields 2 at a free-slip corner. Which one a
-    // level got used to depend on how it was built; keying it off mask_type keeps it uniform.
-    if (solverChoice.mask_type == MaskType::netcdf) {
-        update_mskp(lev);
-    }
+
     vec_msku[lev]->FillBoundary(geom[lev].periodicity());
     vec_mskv[lev]->FillBoundary(geom[lev].periodicity());
     vec_mskp[lev]->FillBoundary(geom[lev].periodicity());

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -117,14 +117,11 @@ REMORA::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
                 BdyVars::null,icomp,false);
     }
 
-    // Not totally sure foextrap is right here
-    FillCoarsePatchPC(lev, time, vec_mskr[lev].get(), vec_mskr[lev-1].get(),
-            foextrap_bc());
-
-    calculate_nodal_masks(lev);
-
-
     set_grid_scale(lev);
+    // After set_grid_scale: an analytic mask reads the grid coordinates it fills. This picks
+    // the same lane level 0 uses, so a level at or below hires_grid_level takes the
+    // high-resolution mask instead of an injection from the coarser level.
+    set_masks(lev);
     stretch_transform(lev);
 
     init_set_vmix(lev);
@@ -297,14 +294,13 @@ REMORA::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionM
     t_new[lev] = time;
     t_old[lev] = time - bogus_large_value;
 
-    init_masks(lev, ba, dm);
-    FillCoarsePatchPC(lev, time, vec_mskr[lev].get(), vec_mskr[lev-1].get(),
-            foextrap_bc());
-    calculate_nodal_masks(lev);
-
     init_stuff(lev, ba, dm);
 
     set_grid_scale(lev);
+    // See MakeNewLevelFromCoarse. The init_masks call further up already allocated the masks
+    // on the new BoxArray -- set_bathymetry_averaged_down needs them there -- so this only
+    // has to fill them.
+    set_masks(lev);
     stretch_transform(lev);
 
     init_set_vmix(lev);

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -416,7 +416,9 @@ void REMORA::resize_stuff(int lev)
     vec_z_phys_nd.resize(lev+1);
 
     vec_h_full_domain.resize(hires_grid_level+1);
-    vec_mskr_full_domain.resize(hires_grid_level+1);
+    // Sized for both hires knobs: the initial-state cascade needs a mask at
+    // hires_init_level, which may sit above hires_grid_level.
+    vec_mskr_full_domain.resize(std::max(hires_grid_level, hires_init_level)+1);
 
     vec_h.resize(lev+1);
     vec_Zt_avg1.resize(lev+1);

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -984,7 +984,8 @@ REMORA::update_mskp (int lev)
         Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);
         Array4<      Real> const& mskp = vec_mskp[lev]->array(mfi);
 
-        Box bx = mfi.tilebox(); bx.grow(IntVect(1,1,0)); bx.makeSlab(2,0);
+        // NGROW rings, not one: the stencil reaches mskr(i-1,j-1), and mskr carries NGROW+1.
+        Box bx = mfi.tilebox(); bx.grow(IntVect(NGROW,NGROW,0)); bx.makeSlab(2,0);
 
         Real cff1 = one;
         Real cff2 = two;
@@ -1030,7 +1031,8 @@ REMORA::calculate_nodal_masks (int lev)
         Array4<      Real> const& mskv = vec_mskv[lev]->array(mfi);
         Array4<      Real> const& mskp = vec_mskp[lev]->array(mfi);
 
-        Box bx = mfi.tilebox(); bx.grow(IntVect(1,1,0)); bx.makeSlab(2,0);
+        // NGROW rings, not one: the stencil reaches mskr(i-1,j-1), and mskr carries NGROW+1.
+        Box bx = mfi.tilebox(); bx.grow(IntVect(NGROW,NGROW,0)); bx.makeSlab(2,0);
 
         ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int)
         {
@@ -1038,6 +1040,75 @@ REMORA::calculate_nodal_masks (int lev)
             mskv(i,j,0) = mskr(i  ,j-1,0) * mskr(i,j,0);
             mskp(i,j,0) = mskr(i-1,j-1,0) * mskr(i,j,0) * mskr(i-1,j,0) * mskr(i,j-1,0);
         });
+    }
+}
+
+/**
+ * Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghost cells.
+ *
+ * The psi mask has two definitions here: the plain product, and ROMS set_masks.F's rule, which
+ * also yields 2 at a free-slip corner. Which one a level got used to depend on how it was
+ * built; keying it off mask_type keeps it uniform across levels.
+ *
+ * @param[in   ] lev    level to operate on
+ */
+void
+REMORA::update_nodal_masks (int lev)
+{
+    calculate_nodal_masks(lev);
+    if (solverChoice.mask_type == MaskType::netcdf) {
+        update_mskp(lev);
+    }
+    vec_msku[lev]->FillBoundary(geom[lev].periodicity());
+    vec_mskv[lev]->FillBoundary(geom[lev].periodicity());
+    vec_mskp[lev]->FillBoundary(geom[lev].periodicity());
+}
+
+/**
+ * Check a grid file's mask_u and mask_v against the mask_rho product ROMS set_masks.F defines.
+ *
+ * Only the level-0 read takes them from a file; every other lane derives them from mask_rho.
+ * Verify the file agrees, so the two cannot disagree about where a face is closed.
+ *
+ * @param[in   ] lev    level to operate on
+ */
+void
+REMORA::verify_file_nodal_masks (int lev)
+{
+    ReduceOps<ReduceOpSum, ReduceOpSum> reduce_op;
+    ReduceData<Long, Long> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+
+    for ( MFIter mfi(*vec_mskr[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
+    {
+        Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);
+        Array4<const Real> const& msku = vec_msku[lev]->const_array(mfi);
+        Array4<const Real> const& mskv = vec_mskv[lev]->const_array(mfi);
+
+        Box bx = mfi.tilebox(); bx.makeSlab(2,0);
+
+        reduce_op.eval(bx, reduce_data, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            -> ReduceTuple
+        {
+            const Real bad_u = amrex::Math::abs(msku(i,j,k) - mskr(i-1,j  ,k) * mskr(i,j,k));
+            const Real bad_v = amrex::Math::abs(mskv(i,j,k) - mskr(i  ,j-1,k) * mskr(i,j,k));
+            return {static_cast<Long>(bad_u > Real(1.0e-12)),
+                    static_cast<Long>(bad_v > Real(1.0e-12))};
+        });
+    }
+
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    Long nbad_u = amrex::get<0>(hv);
+    Long nbad_v = amrex::get<1>(hv);
+    ParallelDescriptor::ReduceLongSum(nbad_u);
+    ParallelDescriptor::ReduceLongSum(nbad_v);
+
+    if (nbad_u > 0 || nbad_v > 0) {
+        amrex::Abort("Land mask on level " + std::to_string(lev) + " is inconsistent: " +
+                     std::to_string(nbad_u) + " mask_u and " + std::to_string(nbad_v) +
+                     " mask_v points differ from the mask_rho product ROMS set_masks.F "
+                     "defines (umask = rmask(i-1,j)*rmask(i,j), vmask likewise). Regenerate "
+                     "the grid file's staggered masks from its mask_rho.");
     }
 }
 
@@ -1052,7 +1123,8 @@ REMORA::fill_3d_masks (int lev)
         Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);
         Array4<      Real> const& mskr3d = vec_mskr3d[lev]->array(mfi);
 
-        Box bx = mfi.tilebox(); bx.grow(IntVect(1,1,0));
+        // No stencil, so this can fill every ring mskr has.
+        Box bx = mfi.tilebox(); bx.grow(IntVect(NGROW+1,NGROW+1,0));
 
         ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -1066,54 +1066,6 @@ REMORA::update_nodal_masks (int lev)
 }
 
 /**
- * Check a grid file's mask_u and mask_v against the mask_rho product ROMS set_masks.F defines.
- *
- * Only the level-0 read takes them from a file; every other lane derives them from mask_rho.
- * Verify the file agrees, so the two cannot disagree about where a face is closed.
- *
- * @param[in   ] lev    level to operate on
- */
-void
-REMORA::verify_file_nodal_masks (int lev)
-{
-    ReduceOps<ReduceOpSum, ReduceOpSum> reduce_op;
-    ReduceData<Long, Long> reduce_data(reduce_op);
-    using ReduceTuple = typename decltype(reduce_data)::Type;
-
-    for ( MFIter mfi(*vec_mskr[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
-    {
-        Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);
-        Array4<const Real> const& msku = vec_msku[lev]->const_array(mfi);
-        Array4<const Real> const& mskv = vec_mskv[lev]->const_array(mfi);
-
-        Box bx = mfi.tilebox(); bx.makeSlab(2,0);
-
-        reduce_op.eval(bx, reduce_data, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            -> ReduceTuple
-        {
-            const Real bad_u = amrex::Math::abs(msku(i,j,k) - mskr(i-1,j  ,k) * mskr(i,j,k));
-            const Real bad_v = amrex::Math::abs(mskv(i,j,k) - mskr(i  ,j-1,k) * mskr(i,j,k));
-            return {static_cast<Long>(bad_u > Real(1.0e-12)),
-                    static_cast<Long>(bad_v > Real(1.0e-12))};
-        });
-    }
-
-    ReduceTuple hv = reduce_data.value(reduce_op);
-    Long nbad_u = amrex::get<0>(hv);
-    Long nbad_v = amrex::get<1>(hv);
-    ParallelDescriptor::ReduceLongSum(nbad_u);
-    ParallelDescriptor::ReduceLongSum(nbad_v);
-
-    if (nbad_u > 0 || nbad_v > 0) {
-        amrex::Abort("Land mask on level " + std::to_string(lev) + " is inconsistent: " +
-                     std::to_string(nbad_u) + " mask_u and " + std::to_string(nbad_v) +
-                     " mask_v points differ from the mask_rho product ROMS set_masks.F "
-                     "defines (umask = rmask(i-1,j)*rmask(i,j), vmask likewise). Regenerate "
-                     "the grid file's staggered masks from its mask_rho.");
-    }
-}
-
-/**
  * @param[in   ] lev    level to operate on
  */
 void

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -1052,9 +1052,7 @@ REMORA::calculate_nodal_masks (int lev)
 /**
  * Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghost cells.
  *
- * The psi mask has two definitions here: the plain product, and ROMS set_masks.F's rule, which
- * also yields 2 at a free-slip corner. Which one a level got used to depend on how it was
- * built; keying it off mask_type keeps it uniform across levels.
+ * Every lane goes through here, so the levels cannot end up with different definitions.
  *
  * @param[in   ] lev    level to operate on
  */
@@ -1062,6 +1060,9 @@ void
 REMORA::update_nodal_masks (int lev)
 {
     calculate_nodal_masks(lev);
+    // The psi mask has two definitions: the plain product calculate_nodal_masks just wrote,
+    // and ROMS set_masks.F's rule, which also yields 2 at a free-slip corner. Which one a
+    // level got used to depend on how it was built; keying it off mask_type keeps it uniform.
     if (solverChoice.mask_type == MaskType::netcdf) {
         update_mskp(lev);
     }

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -421,6 +421,7 @@ void REMORA::resize_stuff(int lev)
     vec_z_phys_nd.resize(lev+1);
 
     vec_h_full_domain.resize(hires_grid_level+1);
+    vec_mskr_full_domain.resize(hires_grid_level+1);
 
     vec_h.resize(lev+1);
     vec_Zt_avg1.resize(lev+1);

--- a/Source/Prob/REMORA_InitAnalyticBathymetry_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticBathymetry_DogboneAnalytic.H
@@ -6,19 +6,26 @@
     if (traditional) {
         mf_h.setVal(Real(10.0));
     } else {
+        // Coordinates from the Geometry rather than remora.vec_xr/vec_yr, as in the mask hook:
+        // the hires_grid_level lane evaluates this on a full-domain MultiFab that is not built
+        // on grids[lev], so the per-level coordinate arrays cannot be indexed with its MFIter.
+        // Matches set_grid_coords_from_grid_scale's (i + 1/2) * dx convention.
+        const Real dx = geom.CellSize(0);
+        const Real dy = geom.CellSize(1);
+
         mf_h.setVal(zero);
         for (MFIter mfi(mf_h, TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            const Box &bx = mfi.growntilebox(IntVect(NGROW,NGROW,0));
+            const Box &bx = mfi.growntilebox();
 
             Array4<      Real> const& h = mf_h.array(mfi);
-            Array4<const Real> const& x_r  = remora.vec_xr[lev]->const_array(mfi);
-            Array4<const Real> const& y_r  = remora.vec_yr[lev]->const_array(mfi);
 
             ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
             {
-                h(i,j,0) = Real(10.0) + (x_r(i,j,0) - Real(4200.0)) * (x_r(i,j,0) - Real(4200.0)) * Real(5.0) / (Real(4200.0) * Real(4200.0)) -
-                            (y_r(i,j,0) - Real(375.0)) * (y_r(i,j,0) - Real(375.0)) * Real(5.0) / (Real(375.0) * Real(375.0));
+                const Real x_r = (i + Real(0.5)) * dx;
+                const Real y_r = (j + Real(0.5)) * dy;
+                h(i,j,0) = Real(10.0) + (x_r - Real(4200.0)) * (x_r - Real(4200.0)) * Real(5.0) / (Real(4200.0) * Real(4200.0)) -
+                            (y_r - Real(375.0)) * (y_r - Real(375.0)) * Real(5.0) / (Real(375.0) * Real(375.0));
             });
         }
     }

--- a/Source/Prob/REMORA_InitAnalyticBathymetry_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticBathymetry_DogboneAnalytic.H
@@ -7,7 +7,7 @@
         mf_h.setVal(Real(10.0));
     } else {
         // Coordinates from the Geometry rather than remora.vec_xr/vec_yr, as in the mask hook:
-        // the hires_grid_level lane evaluates this on a full-domain MultiFab that is not built
+        // the hires_grid_level path evaluates this on a full-domain MultiFab that is not built
         // on grids[lev], so the per-level coordinate arrays cannot be indexed with its MFIter.
         // Matches set_grid_coords_from_grid_scale's (i + 1/2) * dx convention.
         const Real dx = geom.CellSize(0);

--- a/Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H
@@ -6,6 +6,19 @@
     const Real dx = geom.CellSize(0);
     const Real dy = geom.CellSize(1);
 
+    // Defaults put the coast on coarse cell faces at every refinement ratio the tests use,
+    // so every block is entirely land or entirely water. Moving y_lo/y_hi off a coarse face
+    // is what produces a partially-masked coarse cell.
+    ParmParse pp_mask("remora.prob");
+    Real mask_x_lo = Real(2800.0);
+    Real mask_x_hi = Real(5600.0);
+    Real mask_y_lo = Real(250.0);
+    Real mask_y_hi = Real(500.0);
+    pp_mask.query("mask_x_lo", mask_x_lo);
+    pp_mask.query("mask_x_hi", mask_x_hi);
+    pp_mask.query("mask_y_lo", mask_y_lo);
+    pp_mask.query("mask_y_hi", mask_y_hi);
+
     for (MFIter mfi(mf_mskr, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
         // Every grow cell, not just NGROW of them: the full-domain array carries as many as
@@ -20,8 +33,8 @@
         {
             const Real x_r = (i + Real(0.5)) * dx;
             const Real y_r = (j + Real(0.5)) * dy;
-            if ((x_r > Real(2800.0) && x_r < Real(5600.0)) &&
-                (y_r < Real(250.0) || y_r > Real(500.0))) {
+            if ((x_r > mask_x_lo && x_r < mask_x_hi) &&
+                (y_r < mask_y_lo || y_r > mask_y_hi)) {
                 mskr(i,j,0) = zero;
             }
         });

--- a/Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H
@@ -1,5 +1,5 @@
     // Coordinates come from the Geometry rather than remora.vec_xr/vec_yr so that this hook
-    // also works on the full-domain MultiFab used for the hires_grid_level lane, which is
+    // also works on the full-domain MultiFab used for hires_grid_level, which is
     // not built on grids[lev] and so has no per-level coordinate arrays to index. This
     // matches set_grid_coords_from_grid_scale, which puts the rho point of cell i at
     // (i + 1/2) * dx measured from index 0.

--- a/Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticMasks_DogboneAnalytic.H
@@ -1,16 +1,27 @@
+    // Coordinates come from the Geometry rather than remora.vec_xr/vec_yr so that this hook
+    // also works on the full-domain MultiFab used for the hires_grid_level lane, which is
+    // not built on grids[lev] and so has no per-level coordinate arrays to index. This
+    // matches set_grid_coords_from_grid_scale, which puts the rho point of cell i at
+    // (i + 1/2) * dx measured from index 0.
+    const Real dx = geom.CellSize(0);
+    const Real dy = geom.CellSize(1);
+
     for (MFIter mfi(mf_mskr, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
-        const Box &bx = mfi.growntilebox(IntVect(NGROW,NGROW,0));
+        // Every grow cell, not just NGROW of them: the full-domain array carries as many as
+        // the cumulative refinement ratio needs, and any it left unwritten would coarsen
+        // down as water.
+        const Box &bx = mfi.growntilebox();
 
         Array4<      Real> const& mskr = mf_mskr.array(mfi);
-        Array4<const Real> const& x_r  = remora.vec_xr[lev]->const_array(mfi);
-        Array4<const Real> const& y_r  = remora.vec_yr[lev]->const_array(mfi);
 
         // mskr is 1 everywhere already
         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
         {
-            if ((x_r(i,j,0) > Real(2800.0) && x_r(i,j,0) < Real(5600.0)) &&
-                (y_r(i,j,0) < Real(250.0) || y_r(i,j,0) > Real(500.0))) {
+            const Real x_r = (i + Real(0.5)) * dx;
+            const Real y_r = (j + Real(0.5)) * dy;
+            if ((x_r > Real(2800.0) && x_r < Real(5600.0)) &&
+                (y_r < Real(250.0) || y_r > Real(500.0))) {
                 mskr(i,j,0) = zero;
             }
         });

--- a/Source/Prob/REMORA_InitAnalyticProb_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticProb_DogboneAnalytic.H
@@ -6,6 +6,10 @@
     ParmParse pp_prob("remora.prob");
     bool traditional = true;
     pp_prob.query("traditional", traditional);
+    // Equal to the eastern value leaves temperature uniform, which a test needs if its
+    // exact solution is rest.
+    Real temp_west = Real(5.0);
+    pp_prob.query("temp_west", temp_west);
 
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -28,7 +32,7 @@
                     state(i, j, k, Salt_comp) = Real(35.0);
                 }
 
-                state(i,j,k,Temp_comp)= (x_r(i,j,0) < Real(1000.)) ? Real(5.0) : Real(10.0);
+                state(i,j,k,Temp_comp)= (x_r(i,j,0) < Real(1000.)) ? temp_west : Real(10.0);
 
                 // Set tracer = 0 everywhere
                 if (l_do_dye) { state(i, j, k,Tracer_comp) = zero; }

--- a/Source/Prob/REMORA_InitAnalyticZeta_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticZeta_DogboneAnalytic.H
@@ -1,6 +1,11 @@
     mf_zeta.setVal(zero);
 
-    for (MFIter mfi(mf_zeta, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    // Off leaves the free surface flat, which a test needs if its exact solution is rest.
+    ParmParse pp_zeta("remora.prob");
+    bool zeta_bump = true;
+    pp_zeta.query("zeta_bump", zeta_bump);
+
+    for (MFIter mfi(mf_zeta, TilingIfNotGPU()); zeta_bump && mfi.isValid(); ++mfi)
     {
         const Box &bx = mfi.growntilebox(IntVect(1,1,0));
 

--- a/Source/Prob/REMORA_InitAnalyticZeta_DogboneAnalytic.H
+++ b/Source/Prob/REMORA_InitAnalyticZeta_DogboneAnalytic.H
@@ -5,17 +5,19 @@
     bool zeta_bump = true;
     pp_zeta.query("zeta_bump", zeta_bump);
 
-    for (MFIter mfi(mf_zeta, TilingIfNotGPU()); zeta_bump && mfi.isValid(); ++mfi)
-    {
-        const Box &bx = mfi.growntilebox(IntVect(1,1,0));
-
-        Array4<      Real> const& zeta = mf_zeta.array(mfi);
-        Array4<const Real> const& x_r  = remora.vec_xr[lev]->const_array(mfi);
-
-        ParallelFor(bx, 3, [=] AMREX_GPU_DEVICE(int i, int j, int , int n) noexcept
+    if (zeta_bump) {
+        for (MFIter mfi(mf_zeta, TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            if (x_r(i,j,0) < Real(1100.0)) {
-                zeta(i,j,0,n) = Real(-0.00125) * (x_r(i,j,0) - Real(100.0)) + Real(1.25);
-            }
-        });
+            const Box &bx = mfi.growntilebox(IntVect(1,1,0));
+
+            Array4<      Real> const& zeta = mf_zeta.array(mfi);
+            Array4<const Real> const& x_r  = remora.vec_xr[lev]->const_array(mfi);
+
+            ParallelFor(bx, 3, [=] AMREX_GPU_DEVICE(int i, int j, int , int n) noexcept
+            {
+                if (x_r(i,j,0) < Real(1100.0)) {
+                    zeta(i,j,0,n) = Real(-0.00125) * (x_r(i,j,0) - Real(100.0)) + Real(1.25);
+                }
+            });
+        }
     }

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1113,6 +1113,12 @@ public:
      * included, by the rule that a coarse cell is land only if all its fine cells are land */
     void coarsen_masks_with_grow_cells (int crse_lev);
 
+    /** \brief Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghosts */
+    void update_nodal_masks (int lev);
+
+    /** \brief Check a grid file's mask_u and mask_v against the mask_rho product */
+    void verify_file_nodal_masks (int lev);
+
     /** \brief Calculate vertical stretched coordinates */
     void stretch_transform (int lev);
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -397,6 +397,11 @@ public:
     /** \brief Bathymetry data on the whole domain at each potential level **/
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_h_full_domain;
 
+    /** \brief Land/sea mask at cell centers on the whole domain at each potential level.
+     * Specified at hires_grid_level and coarsened down from there, so that a refined
+     * coastline and the bathymetry it goes with come from the same grid. **/
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_mskr_full_domain;
+
     /** \brief Width of cells in the vertical (z-) direction (3D, Hz in ROMS) */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_Hz;
     /** \brief u-volume flux (3D) */
@@ -1100,6 +1105,14 @@ public:
     /** \brief Initialize land-sea masks from file or analytic */
     void set_masks (int lev);
 
+    /** \brief Copy this level's land-sea mask out of the full-domain mask that was coarsened
+     * down from hires_grid_level */
+    void set_masks_averaged_down (int lev);
+
+    /** \brief Coarsen the full-domain rho-mask from crse_lev+1 onto crse_lev, grow cells
+     * included, by the rule that a coarse cell is land only if all its fine cells are land */
+    void coarsen_masks_with_grow_cells (int crse_lev);
+
     /** \brief Calculate vertical stretched coordinates */
     void stretch_transform (int lev);
 
@@ -1231,6 +1244,9 @@ public:
     /** \brief Full domain bathymetry data initialization from analytic */
     void init_bathymetry_full_domain_from_analytic ();
 
+    /** \brief Full domain land-sea mask initialization from analytic */
+    void init_masks_full_domain_from_analytic ();
+
     /** \brief Problem initialization from averaged-down high resolution data */
     void set_init_data_averaged_down (int lev);
     /** \brief Problem initialization from NetCDF file */
@@ -1260,6 +1276,8 @@ public:
     void init_bdry_from_netcdf (int lev);
     /** \brief Mask data initialization from NetCDF file */
     void init_masks_from_netcdf (int lev);
+    /** \brief Full domain high-res mask data initialization from NetCDF file */
+    void init_masks_full_domain_from_netcdf ();
     /** \brief Bathymetry data initialization from NetCDF file */
     void init_bathymetry_from_netcdf (int lev);
     /** \brief Full domain high-res bathymetry data initialization from NetCDF file */

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1119,6 +1119,10 @@ public:
     /** \brief Check a grid file's mask_u and mask_v against the mask_rho product */
     void verify_file_nodal_masks (int lev);
 
+    /** \brief Check every level pair's masks against each other, and every level's mask
+     * values, reporting according to remora.mask_consistency */
+    void check_mask_consistency ();
+
     /** \brief Calculate vertical stretched coordinates */
     void stretch_transform (int lev);
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1113,6 +1113,10 @@ public:
      * included, by the rule that a coarse cell is land only if all its fine cells are land */
     void coarsen_masks_with_grow_cells (int crse_lev);
 
+    /** \brief Coarsen the full-domain bathymetry from crse_lev+1 onto crse_lev, grow cells
+     * included, weighted by the land/sea mask */
+    void coarsen_bathymetry_with_grow_cells (int crse_lev);
+
     /** \brief Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghosts */
     void update_nodal_masks (int lev);
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1127,8 +1127,6 @@ public:
     /** \brief Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghosts */
     void update_nodal_masks (int lev);
 
-    /** \brief Check a grid file's mask_u and mask_v against the mask_rho product */
-    void verify_file_nodal_masks (int lev);
 
     /** \brief Check every level pair's masks against each other, and every level's mask
      * values, reporting according to remora.mask_consistency */

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -558,6 +558,14 @@ public:
     /** \brief land/sea mask at cell centers, copied to all z levels (3D) */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_mskr3d;
 
+    /** \brief the level's rho-, u- and v-masks copied onto the layout of the level above it
+     * coarsened, which is the layout the two-way average-down computes on. Indexed by the
+     * coarse level of the pair. Built on demand and reused until a regrid, since the masks
+     * are a function of position alone and so do not change between them. **/
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_mskr_crse_on_fine;
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_msku_crse_on_fine;
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_mskv_crse_on_fine;
+
     /** \brief horizontal scaling factor: 1 / dx (2D) */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_pm;
     /** \brief horizontal scaling factor: 1 / dy (2D) */
@@ -1127,6 +1135,12 @@ public:
     /** \brief Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghosts */
     void update_nodal_masks (int lev);
 
+    /** \brief Make sure the coarse masks the average-down kernels read sit on the coarsened
+     * layout of level crse_lev+1, rebuilding them if a regrid has moved it */
+    void update_avgdown_masks (int crse_lev);
+
+    /** \brief Drop the cached average-down masks of every level pair that involves lev */
+    void clear_avgdown_masks (int lev);
 
     /** \brief Check every level pair's masks against each other, and every level's mask
      * values, reporting according to remora.mask_consistency */

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1351,6 +1351,11 @@ public:
     void average_down_with_grow_cells(int lev, amrex::Vector<std::unique_ptr<amrex::MultiFab>>& mf,
                                       bool use_mask = false);
 
+    /** \brief Average one field down a level, weighted by the land/sea mask. */
+    void average_down_masked (int crse_lev, const amrex::MultiFab& S_fine,
+                              amrex::MultiFab& S_crse, const amrex::MultiFab& msk_fine,
+                              const amrex::MultiFab& cmsk, int ncomp, int face_dir);
+
     int xvel_bc () const noexcept { return BCVars::xvel_bc(ncons); }
     int yvel_bc () const noexcept { return BCVars::yvel_bc(ncons); }
     int zvel_bc () const noexcept { return BCVars::zvel_bc(ncons); }
@@ -1423,11 +1428,6 @@ private:
 
     /** \brief more flexible version of AverageDown() that lets you average down across multiple levels */
     void AverageDownTo (int crse_lev);
-
-    /** \brief Average one field down a level, weighted by the land/sea mask */
-    void average_down_masked (int crse_lev, const amrex::MultiFab& S_fine,
-                              amrex::MultiFab& S_crse, const amrex::MultiFab& msk_fine,
-                              const amrex::MultiFab& cmsk, int ncomp, int face_dir);
 
     /** \brief Construct FillPatchers */
     void Construct_REMORAFillPatchers (int lev);

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1117,6 +1117,13 @@ public:
      * included, weighted by the land/sea mask */
     void coarsen_bathymetry_with_grow_cells (int crse_lev);
 
+    /** \brief Inject the full-domain rho-mask from fine_lev-1 onto fine_lev, piecewise
+     * constant, grow cells included */
+    void refine_masks_with_grow_cells (int fine_lev);
+
+    /** \brief Make sure the full-domain rho-mask exists on levels 0 through top_lev */
+    void ensure_full_domain_masks (int top_lev);
+
     /** \brief Rebuild the u-, v- and psi-point masks from vec_mskr and fill their ghosts */
     void update_nodal_masks (int lev);
 
@@ -1329,7 +1336,8 @@ public:
     void mask_arrays_for_write (int lev, amrex::Real fill_value, amrex::Real fill_where);
 
     /** \brief Average down from level lev+1 to lev in mf, including grow cells */
-    void average_down_with_grow_cells(int lev, amrex::Vector<std::unique_ptr<amrex::MultiFab>>& mf);
+    void average_down_with_grow_cells(int lev, amrex::Vector<std::unique_ptr<amrex::MultiFab>>& mf,
+                                      bool use_mask = false);
 
     int xvel_bc () const noexcept { return BCVars::xvel_bc(ncons); }
     int yvel_bc () const noexcept { return BCVars::yvel_bc(ncons); }

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1861,6 +1861,9 @@ private:
     /** \brief Set refinement criteria */
     void refinement_criteria_setup();
 
+    /** \brief Reject vertical refinement and accumulate the refinement ratios */
+    void init_ref_ratios ();
+
     /** \brief Holds info for dynamically generated tagging criteria */
     static amrex::Vector<amrex::AMRErrorTag> ref_tags;
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1400,6 +1400,11 @@ private:
     /** \brief more flexible version of AverageDown() that lets you average down across multiple levels */
     void AverageDownTo (int crse_lev);
 
+    /** \brief Average one field down a level, weighted by the land/sea mask */
+    void average_down_masked (int crse_lev, const amrex::MultiFab& S_fine,
+                              amrex::MultiFab& S_crse, const amrex::MultiFab& msk_fine,
+                              const amrex::MultiFab& cmsk, int ncomp, int face_dir);
+
     /** \brief Construct FillPatchers */
     void Construct_REMORAFillPatchers (int lev);
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -307,9 +307,6 @@ public:
     /** \brief Copy maskr to all z levels */
     void fill_3d_masks (int lev);
 
-    /** \brief Set psi-point mask to be consistent with rho-point mask */
-    void update_mskp (int lev);
-
     /** \brief compute dt from CFL considerations */
     amrex::Real estTimeStep (int lev) const;
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1158,6 +1158,52 @@ REMORA::check_mask_consistency ()
 }
 
 /**
+ * Coarsen the full-domain bathymetry from crse_lev+1 down onto crse_lev, grow cells included,
+ * weighted by the land/sea mask.
+ *
+ * Same problem the state has: averaging a coarse cell's whole block mixes in whatever the grid
+ * file holds under land, which on a ROMS grid is a fill value with no physical meaning. A cell
+ * that is wet because some of its fine cells are wet should take the depth of that water.
+ *
+ * Where the entire block is land there is no water to average, but h still has to hold
+ * something, so it falls back to the plain mean. A block that is entirely wet or entirely land
+ * therefore reproduces average_down_with_grow_cells bit for bit -- see
+ * REMORA_MaskedAverageDown.H for why the arithmetic is written this way.
+ *
+ * @param[in   ] crse_lev   level to coarsen onto
+ */
+void
+REMORA::coarsen_bathymetry_with_grow_cells (int crse_lev)
+{
+    auto const& crsema = vec_h_full_domain[crse_lev]->arrays();
+    auto const& finema = vec_h_full_domain[crse_lev+1]->const_arrays();
+    auto const& fmskma = vec_mskr_full_domain[crse_lev+1]->const_arrays();
+    auto ratio = refRatio(crse_lev);
+    auto nghost_crse = cum_ref_ratios[crse_lev];
+    const int ncomp = vec_h_full_domain[crse_lev]->nComp();
+    ParallelFor(*vec_h_full_domain[crse_lev], nghost_crse, ncomp,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+    {
+        const int ii = i * ratio[0];
+        const int jj = j * ratio[1];
+        Real num = zero, den = zero, sum_all = zero;
+        for (int jref = 0; jref < ratio[1]; ++jref) {
+            for (int iref = 0; iref < ratio[0]; ++iref) {
+                const Real hf = finema[box_no](ii+iref, jj+jref, k, n);
+                const Real m = amrex::min(one, fmskma[box_no](ii+iref, jj+jref, k));
+                num += hf * m;
+                den += m;
+                sum_all += hf;
+            }
+        }
+        crsema[box_no](i,j,k,n) = (den > zero)
+                                ? num * (one/den)
+                                : sum_all * (one/Real(ratio[0]*ratio[1]));
+    });
+    Gpu::streamSynchronize();
+}
+
+/**
  * @param[in   ] lev    level to operate on
  */
 void
@@ -1621,6 +1667,35 @@ REMORA::init_only (int lev, Real time)
         set_grid_scale(lev);
     }
 
+    // High-resolution grid data, both sources in one place because the order matters: the mask
+    // is coarsened first, and the bathymetry is then coarsened with it, so a coarse cell only
+    // partly covered by water takes the depth of that water. mask_type and ic_type are set
+    // independently, so each is dispatched on its own.
+    if (lev==0 and hires_grid_level > 0) {
+        allocate_bathymetry_grid_vars_full_domain();
+
+        if (solverChoice.mask_type == MaskType::analytic) {
+            init_masks_full_domain_from_analytic();
+        } else if (solverChoice.mask_type == MaskType::netcdf) {
+#ifdef REMORA_USE_NETCDF
+            amrex::Print() << "Reading high resolution land-sea mask" << std::endl;
+            init_masks_full_domain_from_netcdf();
+            amrex::Print() << "Done reading in high resolution land-sea mask" << std::endl;
+#endif
+        }
+
+        if (solverChoice.ic_type == IC_Type::analytic) {
+            init_bathymetry_full_domain_from_analytic();
+        } else if (solverChoice.ic_type == IC_Type::netcdf) {
+#ifdef REMORA_USE_NETCDF
+            amrex::Print() << "Reading high resolution bathymetry and grid data" << std::endl;
+            init_bathymetry_full_domain_from_netcdf();
+            init_grid_vars_full_domain_from_netcdf();
+            amrex::Print() << "Done reading in high resolution bathymetry and grid data" << std::endl;
+#endif
+        }
+    }
+
 #ifdef REMORA_USE_NETCDF
     if (solverChoice.ic_type == IC_Type::netcdf) {
         init_clim_nudg_coeff(lev);
@@ -1810,20 +1885,6 @@ REMORA::init_only (int lev, Real time)
         init_riv_pos_from_netcdf(lev);
     }
 
-    if (lev==0 and hires_grid_level > 0 and solverChoice.ic_type == IC_Type::netcdf) {
-        amrex::Print() << "Reading high resolution bathymetry and grid data" << std::endl;
-        allocate_bathymetry_grid_vars_full_domain();
-        init_bathymetry_full_domain_from_netcdf();
-        init_grid_vars_full_domain_from_netcdf();
-        amrex::Print() << "Done reading in high resolution bathymetry and grid data" << std::endl;
-    }
-    // Keyed off mask_type rather than ic_type: the two are set independently, and a netcdf
-    // run may well ask for no mask at all.
-    if (lev==0 and hires_grid_level > 0 and solverChoice.mask_type == MaskType::netcdf) {
-        amrex::Print() << "Reading high resolution land-sea mask" << std::endl;
-        init_masks_full_domain_from_netcdf();
-        amrex::Print() << "Done reading in high resolution land-sea mask" << std::endl;
-    }
     if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::netcdf) {
         amrex::Print() << "Reading high resolution initial data" << std::endl;
         allocate_init_full_domain();
@@ -1851,15 +1912,6 @@ REMORA::init_only (int lev, Real time)
         Abort("Not compiled with NetCDF, but using river sources requires NetCDF");
     }
 #endif
-
-    if (lev==0 and hires_grid_level > 0 and solverChoice.ic_type == IC_Type::analytic) {
-        allocate_bathymetry_grid_vars_full_domain();
-        init_bathymetry_full_domain_from_analytic();
-    }
-
-    if (lev==0 and hires_grid_level > 0 and solverChoice.mask_type == MaskType::analytic) {
-        init_masks_full_domain_from_analytic();
-    }
 
     if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::analytic) {
         allocate_init_full_domain();

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1224,7 +1224,9 @@ REMORA::coarsen_bathymetry_with_grow_cells (int crse_lev)
         }
         // All-land: no water to average, but h still has to hold something, so fall back to
         // the plain mean. That also makes an all-wet or all-land group reproduce
-        // average_down_with_grow_cells bit for bit.
+        // average_down_with_grow_cells bit for bit. This is where the bathymetry parts company
+        // with avgdown_masked, which multiplies by the coarse mask and so leaves an all-land
+        // point at zero: a free surface under land need not hold anything, a depth does.
         crsema[box_no](i,j,k,n) = (den > zero)
                                 ? num * (one/den)
                                 : sum_all * (one/Real(ratio[0]*ratio[1]));
@@ -2667,10 +2669,10 @@ namespace {
  */
 void derive_face_mask (const MultiFab& mskr, MultiFab& mskf, int idir)
 {
-    const IntVect nd = (idir == 0) ? IntVect(1,0,0) : IntVect(0,1,0);
+    const IntVect ndir = (idir == 0) ? IntVect(1,0,0) : IntVect(0,1,0);
     // One ring narrower than the rho mask in the normal direction, where the stencil reaches.
-    const IntVect ng = max(mskr.nGrowVect() - nd, IntVect(0));
-    mskf.define(convert(mskr.boxArray(), nd), mskr.DistributionMap(), 1, ng);
+    const IntVect ng = max(mskr.nGrowVect() - ndir, IntVect(0));
+    mskf.define(convert(mskr.boxArray(), ndir), mskr.DistributionMap(), 1, ng);
     mskf.setVal(one);
 
     for (MFIter mfi(mskf, TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -883,7 +883,10 @@ REMORA::set_masks (int lev)
         if (hires_grid_level < 0) {
             if (solverChoice.mask_type == MaskType::analytic) {
                 prob->init_analytic_masks(lev,geom[lev], solverChoice, *this, *vec_mskr[lev]);
-                calculate_nodal_masks(lev);
+                // The analytic hook writes each grid's own cells only, so this is what makes
+                // the mask agree across grid-grid and periodic boundaries.
+                vec_mskr[lev]->FillBoundary(geom[lev].periodicity());
+                update_nodal_masks(lev);
             } else if (solverChoice.mask_type == MaskType::netcdf) {
 #ifdef REMORA_USE_NETCDF
                 amrex::Print() << "Calling init_masks_from_netcdf level " << lev << std::endl;
@@ -901,7 +904,7 @@ REMORA::set_masks (int lev)
             Real dummy_time = zero;
             FillCoarsePatchPC(lev, dummy_time, vec_mskr[lev].get(), vec_mskr[lev-1].get(),
                     foextrap_bc());
-            calculate_nodal_masks(lev);
+            update_nodal_masks(lev);
         } else {
             set_masks_averaged_down(lev);
         }
@@ -921,7 +924,7 @@ REMORA::set_masks_averaged_down (int lev) {
     // is not piecewise constant, so it would put fractional values in a field that the rest
     // of the code compares against 0 and 1 exactly.
     vec_mskr[lev]->FillBoundary(geom[lev].periodicity());
-    calculate_nodal_masks(lev);
+    update_nodal_masks(lev);
 }
 
 /**

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -441,6 +441,10 @@ REMORA::InitData ()
         restart();
 
     }
+
+    // Every level's mask exists by now, whether built from scratch or read back
+    check_mask_consistency();
+
 #ifdef REMORA_USE_MOAB
     InitMOABMesh();
 #endif
@@ -962,6 +966,195 @@ REMORA::coarsen_masks_with_grow_cells (int crse_lev)
         crsema[box_no](i,j,k,n) = (wet > zero) ? one : zero;
     });
     Gpu::streamSynchronize();
+}
+
+
+/**
+ * Check the land-sea masks for what the rest of the code relies on, reporting according to
+ * remora.mask_consistency (abort by default, or warn, or ignore).
+ *
+ * Per level: masks hold only the values they are meant to, since the plotfile writer decides
+ * what to blank by comparing them against 0 exactly; and no water cell has a non-positive
+ * depth, which stretch_transform turns into quiet garbage rather than a crash.
+ *
+ * Per level pair, over the region the finer level covers: no coarse water point sits over
+ * fine points that are all land, since the wet-only average-down would have nothing to
+ * divide by. Coarsening by "wet if any fine cell is wet" makes that unreachable for cell
+ * centers but not for faces -- a coarse u-face is open whenever both its cells are wet, and
+ * their water can all sit away from the shared plane. Closing it would contradict the
+ * coarsening rule, so the only fix is to move the refined grids.
+ */
+void
+REMORA::check_mask_consistency ()
+{
+    BL_PROFILE("REMORA::check_mask_consistency()");
+    if (solverChoice.mask_type == MaskType::none ||
+        solverChoice.mask_consistency == MaskConsistency::ignore) {
+        return;
+    }
+
+    Long nbad_val = 0, nbad_h = 0, ndry_r = 0, ndry_u = 0, ndry_v = 0, nmissed = 0;
+
+    // Per-level checks
+    for (int lev = 0; lev <= finest_level; ++lev)
+    {
+        ReduceOps<ReduceOpSum, ReduceOpSum> reduce_op;
+        ReduceData<Long, Long> reduce_data(reduce_op);
+        using ReduceTuple = typename decltype(reduce_data)::Type;
+
+        for ( MFIter mfi(*vec_mskr[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
+        {
+            Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);
+            Array4<const Real> const& msku = vec_msku[lev]->const_array(mfi);
+            Array4<const Real> const& mskv = vec_mskv[lev]->const_array(mfi);
+            Array4<const Real> const& mskp = vec_mskp[lev]->const_array(mfi);
+            Array4<const Real> const& h    = vec_h[lev]->const_array(mfi);
+
+            Box bx = mfi.tilebox(); bx.makeSlab(2,0);
+
+            reduce_op.eval(bx, reduce_data, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                -> ReduceTuple
+            {
+                auto is_01 = [] (Real v) {
+                    return v == Real(0.0) || v == Real(1.0);
+                };
+                const bool bad = !is_01(mskr(i,j,k)) || !is_01(msku(i,j,k)) ||
+                                 !is_01(mskv(i,j,k)) ||
+                                 !(is_01(mskp(i,j,k)) || mskp(i,j,k) == Real(2.0));
+                const bool bad_h = (mskr(i,j,k) > Real(0.5)) && (h(i,j,k) <= Real(0.0));
+                return {static_cast<Long>(bad), static_cast<Long>(bad_h)};
+            });
+        }
+        ReduceTuple hv = reduce_data.value(reduce_op);
+        nbad_val += amrex::get<0>(hv);
+        nbad_h   += amrex::get<1>(hv);
+    }
+
+    // Level-pair checks, over the region the finer level covers
+    for (int crse_lev = 0; crse_lev < finest_level; ++crse_lev)
+    {
+        const int flev = crse_lev + 1;
+        const IntVect ratio = refRatio(crse_lev);
+        const BoxArray cba = amrex::coarsen(vec_mskr[flev]->boxArray(), ratio);
+        const DistributionMapping& dmf = vec_mskr[flev]->DistributionMap();
+
+        // Sentinel, so an incomplete copy shows up as itself rather than as a coarse land
+        // point that the checks below would quietly pass over.
+        MultiFab cmskr(cba, dmf, 1, 0);
+        MultiFab cmsku(amrex::convert(cba, IntVect(1,0,0)), dmf, 1, 0);
+        MultiFab cmskv(amrex::convert(cba, IntVect(0,1,0)), dmf, 1, 0);
+        cmskr.setVal(-one); cmsku.setVal(-one); cmskv.setVal(-one);
+        cmskr.ParallelCopy(*vec_mskr[crse_lev], 0, 0, 1);
+        cmsku.ParallelCopy(*vec_msku[crse_lev], 0, 0, 1);
+        cmskv.ParallelCopy(*vec_mskv[crse_lev], 0, 0, 1);
+
+        ReduceOps<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum> reduce_op;
+        ReduceData<Long, Long, Long, Long> reduce_data(reduce_op);
+        using ReduceTuple = typename decltype(reduce_data)::Type;
+
+        for ( MFIter mfi(cmskr, TilingIfNotGPU()); mfi.isValid(); ++mfi )
+        {
+            Array4<const Real> const& cr = cmskr.const_array(mfi);
+            Array4<const Real> const& cu = cmsku.const_array(mfi);
+            Array4<const Real> const& cv = cmskv.const_array(mfi);
+            Array4<const Real> const& fr = vec_mskr[flev]->const_array(mfi);
+            Array4<const Real> const& fu = vec_msku[flev]->const_array(mfi);
+            Array4<const Real> const& fv = vec_mskv[flev]->const_array(mfi);
+
+            Box bx = mfi.tilebox(); bx.makeSlab(2,0);
+            const int rx = ratio[0];
+            const int ry = ratio[1];
+
+            reduce_op.eval(bx, reduce_data, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                -> ReduceTuple
+            {
+                const int ii = i * rx;
+                const int jj = j * ry;
+
+                // Cell centers: the whole rx by ry block.
+                Real wet_r = zero;
+                for (int jref = 0; jref < ry; ++jref) {
+                    for (int iref = 0; iref < rx; ++iref) {
+                        wet_r += amrex::min(one, fr(ii+iref, jj+jref, k));
+                    }
+                }
+                // Faces: only the fine faces lying in the coarse face's plane.
+                Real wet_u = zero;
+                for (int jref = 0; jref < ry; ++jref) {
+                    wet_u += amrex::min(one, fu(ii, jj+jref, k));
+                }
+                Real wet_v = zero;
+                for (int iref = 0; iref < rx; ++iref) {
+                    wet_v += amrex::min(one, fv(ii+iref, jj, k));
+                }
+
+                const bool missed = cr(i,j,k) < zero;
+                return {static_cast<Long>(missed),
+                        static_cast<Long>(!missed && cr(i,j,k) > Real(0.5) && wet_r == zero),
+                        static_cast<Long>(cu(i,j,k) > Real(0.5) && wet_u == zero),
+                        static_cast<Long>(cv(i,j,k) > Real(0.5) && wet_v == zero)};
+            });
+        }
+        ReduceTuple hv = reduce_data.value(reduce_op);
+        nmissed += amrex::get<0>(hv);
+        ndry_r  += amrex::get<1>(hv);
+        ndry_u  += amrex::get<2>(hv);
+        ndry_v  += amrex::get<3>(hv);
+    }
+
+    ParallelDescriptor::ReduceLongSum(nbad_val);
+    ParallelDescriptor::ReduceLongSum(nbad_h);
+    ParallelDescriptor::ReduceLongSum(nmissed);
+    ParallelDescriptor::ReduceLongSum(ndry_r);
+    ParallelDescriptor::ReduceLongSum(ndry_u);
+    ParallelDescriptor::ReduceLongSum(ndry_v);
+
+    if (nbad_val == 0 && nbad_h == 0 && nmissed == 0 &&
+        ndry_r == 0 && ndry_u == 0 && ndry_v == 0) {
+        if (verbose > 0) {
+            amrex::Print() << "Land-sea masks are consistent across " << finest_level+1
+                           << " level(s)" << std::endl;
+        }
+        return;
+    }
+
+    std::string msg = "Land-sea mask problems:";
+    if (nbad_val > 0) {
+        msg += "\n  " + std::to_string(nbad_val) + " point(s) where a mask is neither 0 nor 1"
+               " (psi may also be 2). The plotfile writer decides what to blank by comparing"
+               " masks against 0 exactly, so a fractional mask silently stops masking.";
+    }
+    if (nbad_h > 0) {
+        msg += "\n  " + std::to_string(nbad_h) + " water point(s) with depth <= 0."
+               " stretch_transform divides by hc + h, so this is quiet garbage rather than a"
+               " crash.";
+    }
+    if (nmissed > 0) {
+        msg += "\n  " + std::to_string(nmissed) + " refined point(s) with no coarse point"
+               " beneath them, which should be impossible under proper nesting.";
+    }
+    if (ndry_r > 0) {
+        msg += "\n  " + std::to_string(ndry_r) + " coarse water cell(s) with only land"
+               " beneath them.";
+    }
+    if (ndry_u > 0 || ndry_v > 0) {
+        msg += "\n  " + std::to_string(ndry_u) + " coarse u-face(s) and " +
+               std::to_string(ndry_v) + " v-face(s) that are open with no open fine face"
+               " beneath them. The coarse grid cannot see a barrier the fine grid resolves."
+               " Closing the coarse face would contradict the coarsening rule, so move the"
+               " refined grids off it or coarsen the mask by hand.";
+    }
+    if (ndry_r > 0 || ndry_u > 0 || ndry_v > 0) {
+        msg += "\nThe two-way average-down divides by the number of wet fine points, so these"
+               " have no value to take.";
+    }
+    msg += "\nSet remora.mask_consistency = warn to continue anyway.";
+
+    if (solverChoice.mask_consistency == MaskConsistency::abort) {
+        amrex::Abort(msg);
+    } else {
+        amrex::Print() << "WARNING: " << msg << std::endl;
+    }
 }
 
 /**

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -142,28 +142,7 @@ REMORA::REMORA ()
     // Initialize tagging criteria for mesh refinement
     refinement_criteria_setup();
 
-    IntVect cum_ref_ratio = IntVect(1,1,0);
-    cum_ref_ratios.push_back(cum_ref_ratio);
-    // We have already read in the ref_Ratio (via amr.ref_ratio =) but we need to enforce
-    //     that there is no refinement in the vertical so we test on that here.
-    for (int lev = 0; lev < max_level; ++lev)
-    {
-       amrex::Print() << "Refinement ratio at level " << lev << " set to be " <<
-          ref_ratio[lev][0]  << " " << ref_ratio[lev][1]  <<  " " << ref_ratio[lev][2] << std::endl;
-
-       if (ref_ratio[lev][2] != 1)
-       {
-           amrex::Print() << "********************************************************************************" << std::endl;
-           amrex::Print() << "We don't allow refinement in the vertical -- make sure to set ref_ratio = 1 in z" << std::endl;
-           amrex::Print() << "It's possible you set amr.ref_ratio when you meant to set amr.ref_ratio_vect    " << std::endl;
-           amrex::Print() << "********************************************************************************" << std::endl;
-           amrex::Abort();
-       }
-
-       cum_ref_ratio[0] *= ref_ratio[lev][0];
-       cum_ref_ratio[1] *= ref_ratio[lev][1];
-       cum_ref_ratios.push_back(cum_ref_ratio);
-    }
+    init_ref_ratios();
 }
 
 REMORA::REMORA (const amrex::RealBox& rb, int max_level_in, const amrex::Vector<int>& n_cell_in, int coord, const amrex::Vector<amrex::IntVect>& ref_ratio_in, const amrex::Array<int,AMREX_SPACEDIM>& is_per, std::string prefix)
@@ -226,6 +205,29 @@ REMORA::REMORA (const amrex::RealBox& rb, int max_level_in, const amrex::Vector<
 
     refinement_criteria_setup();
 
+    init_ref_ratios();
+}
+
+REMORA::~REMORA ()
+{
+}
+
+/**
+ * Reject refinement in the vertical, and accumulate the refinement ratios.
+ *
+ * Shared by both constructors. It used to be written out in each of them, and the explicit one
+ * had been left without the cum_ref_ratios half -- so the vector stayed empty, and every
+ * full-domain hires array and every mask coarsening that indexes it read out of bounds.
+ */
+void
+REMORA::init_ref_ratios ()
+{
+    AMREX_ALWAYS_ASSERT(cum_ref_ratios.empty());
+
+    IntVect cum_ref_ratio = IntVect(1,1,0);
+    cum_ref_ratios.push_back(cum_ref_ratio);
+    // We have already read in the ref_ratio (via amr.ref_ratio =) but we need to enforce
+    //     that there is no refinement in the vertical so we test on that here.
     for (int lev = 0; lev < max_level; ++lev)
     {
        amrex::Print() << "Refinement ratio at level " << lev << " set to be " <<
@@ -239,12 +241,13 @@ REMORA::REMORA (const amrex::RealBox& rb, int max_level_in, const amrex::Vector<
            amrex::Print() << "********************************************************************************" << std::endl;
            amrex::Abort();
        }
+
+       cum_ref_ratio[0] *= ref_ratio[lev][0];
+       cum_ref_ratio[1] *= ref_ratio[lev][1];
+       cum_ref_ratios.push_back(cum_ref_ratio);
     }
 }
 
-REMORA::~REMORA ()
-{
-}
 
 void
 REMORA::init_scalar_metadata ()

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -4,6 +4,7 @@
 
 #include <REMORA_prob_common.H>
 #include <REMORA.H>
+#include <REMORA_MaskedAverageDown.H>
 
 #ifdef REMORA_USE_NETCDF
 #include "REMORA_NCFile.H"
@@ -988,8 +989,7 @@ void
 REMORA::check_mask_consistency ()
 {
     BL_PROFILE("REMORA::check_mask_consistency()");
-    if (solverChoice.mask_type == MaskType::none ||
-        solverChoice.mask_consistency == MaskConsistency::ignore) {
+    if (!solverChoice.do_check_mask_consistency || solverChoice.mask_type == MaskType::none) {
         return;
     }
 
@@ -2345,24 +2345,93 @@ void
 REMORA::AverageDownTo (int crse_lev)
 {
     BL_PROFILE("REMORA::AverageDownTo()");
-    average_down(*cons_new[crse_lev+1], *cons_new[crse_lev],
-                 0, cons_new[crse_lev]->nComp(), refRatio(crse_lev));
-    average_down(*vec_Zt_avg1[crse_lev+1].get(), *vec_Zt_avg1[crse_lev].get(),
-                 0, vec_Zt_avg1[crse_lev]->nComp(), refRatio(crse_lev));
+    const int flev = crse_lev + 1;
+    const IntVect ratio = refRatio(crse_lev);
 
-    Array<MultiFab*,AMREX_SPACEDIM>  faces_crse;
-    Array<MultiFab*,AMREX_SPACEDIM>  faces_fine;
-    faces_crse[0] = xvel_new[crse_lev];
-    faces_crse[1] = yvel_new[crse_lev];
-    faces_crse[2] = zvel_new[crse_lev];
+    // The masks live on the levels' own layouts, but the kernels walk the coarsened-fine one,
+    // so pull the coarse masks onto it first. Convert the coarsened cell-centered BoxArray
+    // rather than coarsening a converted one: on a face BoxArray the two do not commute.
+    const BoxArray cba = amrex::coarsen(vec_mskr[flev]->boxArray(), ratio);
+    const DistributionMapping& dmf = vec_mskr[flev]->DistributionMap();
 
-    faces_fine[0] = xvel_new[crse_lev+1];
-    faces_fine[1] = yvel_new[crse_lev+1];
-    faces_fine[2] = zvel_new[crse_lev+1];
+    MultiFab cmskr(cba,                                  dmf, 1, 0);
+    MultiFab cmsku(amrex::convert(cba, IntVect(1,0,0)),  dmf, 1, 0);
+    MultiFab cmskv(amrex::convert(cba, IntVect(0,1,0)),  dmf, 1, 0);
+    cmskr.ParallelCopy(*vec_mskr[crse_lev], 0, 0, 1);
+    cmsku.ParallelCopy(*vec_msku[crse_lev], 0, 0, 1);
+    cmskv.ParallelCopy(*vec_mskv[crse_lev], 0, 0, 1);
 
-    average_down_faces(GetArrOfConstPtrs(faces_fine), faces_crse,
-                       refRatio(crse_lev),geom[crse_lev]);
+    // Which mask goes with which field follows the ROMS fine2coarse call sites: rmask for the
+    // free surface and the tracers, umask and vmask for the momenta.
+    average_down_masked(crse_lev, *cons_new[flev], *cons_new[crse_lev],
+                        *vec_mskr[flev], cmskr, cons_new[crse_lev]->nComp(), -1);
+    average_down_masked(crse_lev, *vec_Zt_avg1[flev], *vec_Zt_avg1[crse_lev],
+                        *vec_mskr[flev], cmskr, vec_Zt_avg1[crse_lev]->nComp(), -1);
+    average_down_masked(crse_lev, *xvel_new[flev], *xvel_new[crse_lev],
+                        *vec_msku[flev], cmsku, 1, 0);
+    average_down_masked(crse_lev, *yvel_new[flev], *yvel_new[crse_lev],
+                        *vec_mskv[flev], cmskv, 1, 1);
+    average_down_masked(crse_lev, *zvel_new[flev], *zvel_new[crse_lev],
+                        *vec_mskr[flev], cmskr, 1, 2);
+
     stretch_transform(crse_lev);
+}
+
+/**
+ * Average one field from crse_lev+1 onto crse_lev, weighting by the land/sea mask.
+ *
+ * Follows amrex::average_down's non-MFIter-safe branch, since coarsen(grids[flev]) does not
+ * match grids[crse_lev] in general: compute onto a temporary on the coarsened-fine layout,
+ * then ParallelCopy that onto the coarse level. The periodicity arguments match what
+ * average_down and average_down_faces pass, so a run with no mask is unaffected.
+ *
+ * @param[in   ] crse_lev   level to average down to
+ * @param[in   ] S_fine     fine-level field
+ * @param[out  ] S_crse     coarse-level field
+ * @param[in   ] msk_fine   fine-level mask, on S_fine's layout and nodality
+ * @param[in   ] cmsk       coarse-level mask, already on the coarsened-fine layout
+ * @param[in   ] ncomp      number of components to average
+ * @param[in   ] face_dir   face direction, or -1 for a cell-centered field
+ */
+void
+REMORA::average_down_masked (int crse_lev, const MultiFab& S_fine, MultiFab& S_crse,
+                             const MultiFab& msk_fine, const MultiFab& cmsk,
+                             int ncomp, int face_dir)
+{
+    BL_PROFILE("REMORA::average_down_masked()");
+    const IntVect ratio = refRatio(crse_lev);
+
+    BoxArray cba = amrex::coarsen(S_fine.boxArray(), ratio);
+    MultiFab ctmp(cba, S_fine.DistributionMap(), ncomp, 0);
+
+    for (MFIter mfi(ctmp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        Array4<      Real> const& c  = ctmp.array(mfi);
+        Array4<const Real> const& f  = S_fine.const_array(mfi);
+        Array4<const Real> const& fm = msk_fine.const_array(mfi);
+        Array4<const Real> const& cm = cmsk.const_array(mfi);
+
+        if (face_dir < 0) {
+            ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+            {
+                REMORAMaskedAvgDown::avgdown_masked(i,j,k,n,c,f,fm,cm,0,0,ratio);
+            });
+        } else {
+            ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+            {
+                REMORAMaskedAvgDown::avgdown_faces_masked(i,j,k,n,c,f,fm,cm,0,0,ratio,face_dir);
+            });
+        }
+    }
+    Gpu::streamSynchronize();
+
+    if (face_dir < 0) {
+        S_crse.ParallelCopy(ctmp, 0, 0, ncomp);
+    } else {
+        S_crse.ParallelCopy(ctmp, 0, 0, ncomp, IntVect(0), IntVect(0),
+                            geom[crse_lev].periodicity());
+    }
 }
 
 /**

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -956,7 +956,7 @@ REMORA::coarsen_masks_with_grow_cells (int crse_lev)
         Real wet = zero;
         for (int jref = 0; jref < ratio[1]; ++jref) {
             for (int iref = 0; iref < ratio[0]; ++iref) {
-                wet += amrex::min(one, finema[box_no](ii+iref, jj+jref, k, n));
+                wet += amrex::min(Real(1.0), finema[box_no](ii+iref, jj+jref, k, n));
             }
         }
         crsema[box_no](i,j,k,n) = (wet > zero) ? one : zero;
@@ -1077,7 +1077,7 @@ REMORA::check_mask_consistency ()
                 Real wet_r = zero;
                 for (int jref = 0; jref < ry; ++jref) {
                     for (int iref = 0; iref < rx; ++iref) {
-                        wet_r += amrex::min(one, fr(ii+iref, jj+jref, k));
+                        wet_r += amrex::min(Real(1.0), fr(ii+iref, jj+jref, k));
                     }
                 }
 
@@ -1098,7 +1098,7 @@ REMORA::check_mask_consistency ()
 
                 Real wet_u = zero;
                 for (int jref = 0; jref < ry; ++jref) {
-                    wet_u += amrex::min(one, fu(ii, jj+jref, k));
+                    wet_u += amrex::min(Real(1.0), fu(ii, jj+jref, k));
                 }
 
                 const bool missed = cu(i,j,k) < zero;
@@ -1117,7 +1117,7 @@ REMORA::check_mask_consistency ()
 
                 Real wet_v = zero;
                 for (int iref = 0; iref < rx; ++iref) {
-                    wet_v += amrex::min(one, fv(ii+iref, jj, k));
+                    wet_v += amrex::min(Real(1.0), fv(ii+iref, jj, k));
                 }
 
                 const bool missed = cv(i,j,k) < zero;
@@ -1216,7 +1216,7 @@ REMORA::coarsen_bathymetry_with_grow_cells (int crse_lev)
         for (int jref = 0; jref < ratio[1]; ++jref) {
             for (int iref = 0; iref < ratio[0]; ++iref) {
                 const Real hf = finema[box_no](ii+iref, jj+jref, k, n);
-                const Real m = amrex::min(one, fmskma[box_no](ii+iref, jj+jref, k));
+                const Real m = amrex::min(Real(1.0), fmskma[box_no](ii+iref, jj+jref, k));
                 num += hf * m;
                 den += m;
                 sum_all += hf;

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -864,15 +864,8 @@ REMORA::set_analytic_vmix(int lev) {
 /**
  * Initialize the land-sea mask on this level.
  *
- * This mirrors set_bathymetry: the mask is specified exactly once -- on level 0, or, when a
- * high-resolution grid covering the entire domain is supplied, at hires_grid_level -- and
- * every other level is derived from that one specification. No level ever supplies its own
- * independent mask, so the levels cannot disagree about where the coastline is.
- *
- * The hires lane is what lets a refined level carry a better-resolved coastline. It also
- * closes a gap: with hires_grid_level > 0 the bathymetry already came from the fine grid
- * while the mask did not, so a run could have high-resolution depths under a coarse
- * coastline, and needed a level-0 grid file purely to supply that coarse mask.
+ * Mirrors set_bathymetry: the mask is specified once, on level 0 or at hires_grid_level, and
+ * every other level derived from it, so the levels cannot disagree about the coastline.
  *
  * @param[in   ] lev    level to operate on
  */
@@ -927,23 +920,20 @@ void
 REMORA::set_masks_averaged_down (int lev) {
     ParallelCopy(*vec_mskr[lev].get(), *vec_mskr_full_domain[lev].get(), 0, 0, 1,
             vec_mskr_full_domain[lev]->nGrowVect(),vec_mskr[lev]->nGrowVect());
-    // Deliberately not a FillPatch, unlike the bathymetry and grid-variable analogues: the
-    // interpolation from the coarser level that FillPatch would do for uncovered ghost cells
-    // is not piecewise constant, so it would put fractional values in a field that the rest
+    // Not a FillPatch, unlike the bathymetry analogue: its interpolation from the coarser
+    // level is not piecewise constant, so it would put fractional values in a mask the rest
     // of the code compares against 0 and 1 exactly.
     vec_mskr[lev]->FillBoundary(geom[lev].periodicity());
     update_nodal_masks(lev);
 }
 
 /**
- * Coarsen the full-domain rho-mask from crse_lev+1 down onto crse_lev, grow cells included,
- * so that a coarse cell is land only if every one of its fine cells is land.
+ * Coarsen the full-domain rho-mask from crse_lev+1 onto crse_lev, grow cells included, so a
+ * coarse cell is land only if every one of its fine cells is land.
  *
- * This is the counterpart of average_down_with_grow_cells, which cannot be used for a mask:
- * an arithmetic mean of a partially-wet block gives a fractional value, and the mask has to
- * stay exactly 0 or 1. Taking "wet if any fine cell is wet" also means the coarse level
- * never declares land where the fine grid found water, so no water resolved by the fine
- * grid is lost when the levels are coupled.
+ * average_down_with_grow_cells cannot be used: an arithmetic mean over a partly wet group of
+ * fine cells gives a fractional value, and the mask has to stay exactly 0 or 1. Taking the
+ * cell as wet also means the coarse level never declares land where the fine grid found water.
  *
  * @param[in   ] crse_lev   level to coarsen onto
  */
@@ -953,8 +943,7 @@ REMORA::coarsen_masks_with_grow_cells (int crse_lev)
     auto const& crsema = vec_mskr_full_domain[crse_lev]->arrays();
     auto const& finema = vec_mskr_full_domain[crse_lev+1]->const_arrays();
     auto ratio = refRatio(crse_lev);
-    // Same grow-cell budget as average_down_with_grow_cells; the mask is cell-centered, so
-    // there is no index-type correction to make.
+    // As in average_down_with_grow_cells, but cell-centered, so no index-type correction.
     auto nghost_crse = cum_ref_ratios[crse_lev];
     ParallelFor(*vec_mskr_full_domain[crse_lev], nghost_crse, 1,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
@@ -974,19 +963,17 @@ REMORA::coarsen_masks_with_grow_cells (int crse_lev)
 
 
 /**
- * Check the land-sea masks for what the rest of the code relies on, reporting according to
- * remora.mask_consistency (abort by default, or warn, or ignore).
+ * Check the land-sea masks for what the rest of the code relies on. Only runs when
+ * remora.check_mask_consistency is set; remora.mask_consistency picks abort or warn.
  *
- * Per level: masks hold only the values they are meant to, since the plotfile writer decides
- * what to blank by comparing them against 0 exactly; and no water cell has a non-positive
- * depth, which stretch_transform turns into quiet garbage rather than a crash.
+ * Per level: the masks hold only the values they are meant to, since the plotfile writer
+ * decides what to blank by comparing them against 0 exactly, and no water cell has a
+ * non-positive depth, which stretch_transform turns into quiet garbage rather than a crash.
  *
  * Per level pair, over the region the finer level covers: no coarse water point sits over
- * fine points that are all land, since the wet-only average-down would have nothing to
- * divide by. Coarsening by "wet if any fine cell is wet" makes that unreachable for cell
- * centers but not for faces -- a coarse u-face is open whenever both its cells are wet, and
- * their water can all sit away from the shared plane. Closing it would contradict the
- * coarsening rule, so the only fix is to move the refined grids.
+ * fine points that are all land, which would leave the average-down nothing to divide by.
+ * Coarsening makes that unreachable for cell centers but not for faces, since a coarse u-face
+ * is open whenever both its cells are wet and their water can sit away from the shared plane.
  */
 void
 REMORA::check_mask_consistency ()
@@ -1161,17 +1148,15 @@ REMORA::check_mask_consistency ()
 }
 
 /**
- * Coarsen the full-domain bathymetry from crse_lev+1 down onto crse_lev, grow cells included,
+ * Coarsen the full-domain bathymetry from crse_lev+1 onto crse_lev, grow cells included,
  * weighted by the land/sea mask.
  *
- * Same problem the state has: averaging a coarse cell's whole block mixes in whatever the grid
- * file holds under land, which on a ROMS grid is a fill value with no physical meaning. A cell
- * that is wet because some of its fine cells are wet should take the depth of that water.
- *
- * Where the entire block is land there is no water to average, but h still has to hold
- * something, so it falls back to the plain mean. A block that is entirely wet or entirely land
- * therefore reproduces average_down_with_grow_cells bit for bit -- see
- * REMORA_MaskedAverageDown.H for why the arithmetic is written this way.
+ * Averaging every fine cell would mix in whatever the grid file holds under land, which on a
+ * ROMS grid is a fill value with no physical meaning. A wet coarse cell should take the depth
+ * of the water under it. Where every fine cell is land there is none to average, but h still
+ * has to hold something, so that falls back to the plain mean -- which also makes an all-wet
+ * or all-land group reproduce average_down_with_grow_cells bit for bit. See
+ * REMORA_MaskedAverageDown.H for why the arithmetic is written the way it is.
  *
  * @param[in   ] crse_lev   level to coarsen onto
  */
@@ -2405,9 +2390,9 @@ REMORA::AverageDownTo (int crse_lev)
     const int flev = crse_lev + 1;
     const IntVect ratio = refRatio(crse_lev);
 
-    // The masks live on the levels' own layouts, but the kernels walk the coarsened-fine one,
-    // so pull the coarse masks onto it first. Convert the coarsened cell-centered BoxArray
-    // rather than coarsening a converted one: on a face BoxArray the two do not commute.
+    // The kernels walk the coarsened-fine layout, so pull the coarse masks onto it first.
+    // Convert the coarsened cell-centered BoxArray rather than coarsening a converted one:
+    // on a face BoxArray those two do not commute.
     const BoxArray cba = amrex::coarsen(vec_mskr[flev]->boxArray(), ratio);
     const DistributionMapping& dmf = vec_mskr[flev]->DistributionMap();
 
@@ -2440,7 +2425,7 @@ REMORA::AverageDownTo (int crse_lev)
  * Follows amrex::average_down's non-MFIter-safe branch, since coarsen(grids[flev]) does not
  * match grids[crse_lev] in general: compute onto a temporary on the coarsened-fine layout,
  * then ParallelCopy that onto the coarse level. The periodicity arguments match what
- * average_down and average_down_faces pass, so a run with no mask is unaffected.
+ * average_down and average_down_faces pass.
  *
  * @param[in   ] crse_lev   level to average down to
  * @param[in   ] S_fine     fine-level field
@@ -2512,7 +2497,7 @@ REMORA::refine_masks_with_grow_cells (int fine_lev)
         // amrex::coarsen floors rather than truncating, which is what the negative indices of
         // the grow cells need.
         finema[box_no](i,j,k,n) = crsema[box_no](amrex::coarsen(i, ratio[0]),
-                                                amrex::coarsen(j, ratio[1]), k, n);
+                                                 amrex::coarsen(j, ratio[1]), k, n);
     });
     Gpu::streamSynchronize();
 }
@@ -2520,9 +2505,8 @@ REMORA::refine_masks_with_grow_cells (int fine_lev)
 /**
  * Make sure the full-domain rho-mask exists on levels 0 through top_lev.
  *
- * The mask is specified once and every other level derived from it, so this only fills what
- * the hires_grid_level cascade has not: levels above it, by injection, and level 0 itself when
- * there is no high-resolution grid at all and the mask was given per-level instead.
+ * Only fills what the hires_grid_level coarsening has not: levels above it, by injection, and
+ * level 0 itself when there is no high-resolution grid and the mask was given per level.
  *
  * @param[in   ] top_lev   highest level that needs a mask
  */
@@ -2561,17 +2545,15 @@ REMORA::ensure_full_domain_masks (int top_lev)
 /**
  * Average a full-domain field from crse_lev+1 onto crse_lev, grow cells included.
  *
- * With use_mask, the mask-weighted mean of REMORAMaskedAvgDown is used instead of the plain
- * one, so that the initial state on a coarse cell only partly covered by water comes from that
- * water rather than from a mean diluted by land. That is the same formula AverageDownTo applies
- * every step, so the initial and the running state agree on what a land point holds.
- *
- * Leave use_mask off for grid metrics: a cell size is perfectly well defined under land, and
- * masking pm/pn would corrupt it.
+ * With use_mask this takes REMORAMaskedAvgDown's mask-weighted mean instead of the plain one,
+ * so the initial state on a coarse cell only partly covered by water comes from that water.
+ * It is the formula AverageDownTo applies every step, so the initial and the running state
+ * agree on what a land point holds. Leave use_mask off for grid metrics: a cell size is well
+ * defined under land, and masking pm/pn would corrupt it.
  *
  * @param[in   ] crse_lev   level to average data down to
  * @param[inout] vec_mf     vector over levels of multifabs containing data to average
- * @param[in   ] use_mask   weight by the land/sea mask rather than averaging the whole block
+ * @param[in   ] use_mask   weight by the land/sea mask rather than averaging every fine cell
  */
 void
 REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<MultiFab>>& vec_mf,
@@ -2585,17 +2567,17 @@ REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<Multi
 
     const bool masked = use_mask && (solverChoice.mask_type != MaskType::none);
     if (masked) {
-        // The full-domain arrays are one box per level on a matching DistributionMapping, so an
-        // MFIter over one indexes the other. Assert it rather than assume it.
+        // One box per level on a matching DistributionMapping, so an MFIter over one array
+        // indexes the other. Assert it rather than assume it.
         AMREX_ALWAYS_ASSERT(vec_mskr_full_domain[crse_lev] && vec_mskr_full_domain[crse_lev+1]);
         AMREX_ALWAYS_ASSERT(vec_mskr_full_domain[crse_lev]->boxArray().size() ==
                             vec_mf[crse_lev]->boxArray().size());
         AMREX_ALWAYS_ASSERT(vec_mskr_full_domain[crse_lev]->DistributionMap() ==
                             vec_mf[crse_lev]->DistributionMap());
 
-        // Face masks are derived here rather than stored: nothing else needs them, and a
-        // derived one cannot drift out of sync with the rho mask it comes from. The rule is
-        // ROMS set_masks.F's, msku = mskr(i-1,j)*mskr(i,j).
+        // Face masks are derived rather than stored: nothing else needs them, and a derived
+        // one cannot drift out of sync with the rho mask. ROMS set_masks.F's rule is
+        // msku = mskr(i-1,j)*mskr(i,j).
         const int idir = (index_type[0]==1) ? 0 : ((index_type[1]==1) ? 1 : -1);
         MultiFab fmsk, cmsk;
         if (idir >= 0) {

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -2542,6 +2542,37 @@ REMORA::ensure_full_domain_masks (int top_lev)
     }
 }
 
+namespace {
+/**
+ * Build a face-centered mask from a rho-point one, following ROMS set_masks.F:
+ * msku = mskr(i-1,j)*mskr(i,j) and mskv = mskr(i,j-1)*mskr(i,j).
+ *
+ * Derived where it is needed rather than stored. Only the full-domain average-down wants
+ * these, at most once per level during initialization, so a stored pair would be two more
+ * arrays to keep in step with the rho mask for no measurable saving.
+ */
+void derive_face_mask (const MultiFab& mskr, MultiFab& mskf, int idir)
+{
+    const IntVect nd = (idir == 0) ? IntVect(1,0,0) : IntVect(0,1,0);
+    // One ring narrower than the rho mask in the normal direction, where the stencil reaches.
+    const IntVect ng = max(mskr.nGrowVect() - nd, IntVect(0));
+    mskf.define(convert(mskr.boxArray(), nd), mskr.DistributionMap(), 1, ng);
+    mskf.setVal(one);
+
+    for (MFIter mfi(mskf, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.growntilebox();
+        Array4<      Real> const& mf = mskf.array(mfi);
+        Array4<const Real> const& mr = mskr.const_array(mfi);
+        const int l_idir = idir;
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            mf(i,j,k) = (l_idir == 0) ? mr(i-1,j,0) * mr(i,j,0)
+                                      : mr(i,j-1,0) * mr(i,j,0);
+        });
+    }
+}
+} // namespace
+
 /**
  * Average a full-domain field from crse_lev+1 onto crse_lev, grow cells included.
  *
@@ -2575,33 +2606,11 @@ REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<Multi
         AMREX_ALWAYS_ASSERT(vec_mskr_full_domain[crse_lev]->DistributionMap() ==
                             vec_mf[crse_lev]->DistributionMap());
 
-        // Face masks are derived rather than stored: nothing else needs them, and a derived
-        // one cannot drift out of sync with the rho mask. ROMS set_masks.F's rule is
-        // msku = mskr(i-1,j)*mskr(i,j).
         const int idir = (index_type[0]==1) ? 0 : ((index_type[1]==1) ? 1 : -1);
         MultiFab fmsk, cmsk;
         if (idir >= 0) {
-            const IntVect nd = (idir == 0) ? IntVect(1,0,0) : IntVect(0,1,0);
-            for (int which = 0; which < 2; ++which) {
-                const int mlev = crse_lev + 1 - which;
-                MultiFab& dst = (which == 0) ? fmsk : cmsk;
-                const MultiFab& src = *vec_mskr_full_domain[mlev];
-                // One ring narrower than the rho mask, since the stencil reaches back a cell.
-                const IntVect ng = max(src.nGrowVect() - nd, IntVect(0));
-                dst.define(convert(src.boxArray(), nd), src.DistributionMap(), 1, ng);
-                dst.setVal(one);
-                for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                    const Box& bx = mfi.growntilebox();
-                    Array4<      Real> const& mf = dst.array(mfi);
-                    Array4<const Real> const& mr = src.const_array(mfi);
-                    const int l_idir = idir;
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                    {
-                        mf(i,j,k) = (l_idir == 0) ? mr(i-1,j,0) * mr(i,j,0)
-                                                  : mr(i,j-1,0) * mr(i,j,0);
-                    });
-                }
-            }
+            derive_face_mask(*vec_mskr_full_domain[crse_lev+1], fmsk, idir);
+            derive_face_mask(*vec_mskr_full_domain[crse_lev  ], cmsk, idir);
         }
         auto const& fmskma = (idir >= 0) ? fmsk.const_arrays()
                                          : vec_mskr_full_domain[crse_lev+1]->const_arrays();

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -248,7 +248,6 @@ REMORA::init_ref_ratios ()
     }
 }
 
-
 void
 REMORA::init_scalar_metadata ()
 {
@@ -872,6 +871,10 @@ REMORA::set_analytic_vmix(int lev) {
 void
 REMORA::set_masks (int lev)
 {
+    // Ahead of the mask_type == none return as well: that lane still fills the masks, and
+    // AverageDownTo still reads them, so its cached copies go stale here too.
+    clear_avgdown_masks(lev);
+
     if (solverChoice.mask_type == MaskType::none) {
         fill_3d_masks(lev);
         return;
@@ -2381,6 +2384,67 @@ REMORA::AverageDown ()
 }
 
 /**
+ * Drop the cached average-down masks of every level pair that involves lev, so the next
+ * AverageDownTo rebuilds them.
+ *
+ * Called from set_masks, which is the one place a level's mask is written, so a regrid cannot
+ * leave a cached copy of a mask that no longer exists behind.
+ *
+ * @param[in   ] lev   level whose mask has just been rebuilt
+ */
+void
+REMORA::clear_avgdown_masks (int lev)
+{
+    // lev as the coarse half of a pair, and lev as the fine half, whose layout is what the
+    // cached arrays are built on.
+    for (int crse_lev : {lev-1, lev}) {
+        if (crse_lev >= 0 && crse_lev < static_cast<int>(vec_mskr_crse_on_fine.size())) {
+            vec_mskr_crse_on_fine[crse_lev].reset();
+            vec_msku_crse_on_fine[crse_lev].reset();
+            vec_mskv_crse_on_fine[crse_lev].reset();
+        }
+    }
+}
+
+/**
+ * Make sure the coarse rho-, u- and v-masks are defined on the layout average_down_masked
+ * computes on: level crse_lev+1's grids coarsened, rather than level crse_lev's own grids.
+ *
+ * The masks are a function of position alone, so between regrids this is the same answer every
+ * step; building it once turns three allocations and three ParallelCopy calls per step into
+ * three per regrid. clear_avgdown_masks drops the cache when a mask is rewritten, and the
+ * layout comparison below catches anything that reaches here without going through it.
+ *
+ * @param[in   ] crse_lev   coarse level of the pair
+ */
+void
+REMORA::update_avgdown_masks (int crse_lev)
+{
+    BL_PROFILE("REMORA::update_avgdown_masks()");
+    const int flev = crse_lev + 1;
+    const IntVect ratio = refRatio(crse_lev);
+
+    const BoxArray cba = amrex::coarsen(vec_mskr[flev]->boxArray(), ratio);
+    const DistributionMapping& dmf = vec_mskr[flev]->DistributionMap();
+
+    if (vec_mskr_crse_on_fine[crse_lev] &&
+        vec_mskr_crse_on_fine[crse_lev]->boxArray() == cba &&
+        vec_mskr_crse_on_fine[crse_lev]->DistributionMap() == dmf) {
+        return;
+    }
+
+    vec_mskr_crse_on_fine[crse_lev].reset(new MultiFab(cba, dmf, 1, 0));
+    vec_msku_crse_on_fine[crse_lev].reset(
+            new MultiFab(amrex::convert(cba, IntVect(1,0,0)), dmf, 1, 0));
+    vec_mskv_crse_on_fine[crse_lev].reset(
+            new MultiFab(amrex::convert(cba, IntVect(0,1,0)), dmf, 1, 0));
+
+    vec_mskr_crse_on_fine[crse_lev]->ParallelCopy(*vec_mskr[crse_lev], 0, 0, 1);
+    vec_msku_crse_on_fine[crse_lev]->ParallelCopy(*vec_msku[crse_lev], 0, 0, 1);
+    vec_mskv_crse_on_fine[crse_lev]->ParallelCopy(*vec_mskv[crse_lev], 0, 0, 1);
+}
+
+/**
  * @param[in   ] crse_lev  level to average down to
  */
 void
@@ -2388,20 +2452,14 @@ REMORA::AverageDownTo (int crse_lev)
 {
     BL_PROFILE("REMORA::AverageDownTo()");
     const int flev = crse_lev + 1;
-    const IntVect ratio = refRatio(crse_lev);
 
-    // The kernels walk the coarsened-fine layout, so pull the coarse masks onto it first.
-    // Convert the coarsened cell-centered BoxArray rather than coarsening a converted one:
-    // on a face BoxArray those two do not commute.
-    const BoxArray cba = amrex::coarsen(vec_mskr[flev]->boxArray(), ratio);
-    const DistributionMapping& dmf = vec_mskr[flev]->DistributionMap();
-
-    MultiFab cmskr(cba,                                  dmf, 1, 0);
-    MultiFab cmsku(amrex::convert(cba, IntVect(1,0,0)),  dmf, 1, 0);
-    MultiFab cmskv(amrex::convert(cba, IntVect(0,1,0)),  dmf, 1, 0);
-    cmskr.ParallelCopy(*vec_mskr[crse_lev], 0, 0, 1);
-    cmsku.ParallelCopy(*vec_msku[crse_lev], 0, 0, 1);
-    cmskv.ParallelCopy(*vec_mskv[crse_lev], 0, 0, 1);
+    // average_down_masked indexes the coarse mask with the same MFIter as its coarsened-fine
+    // temporary, so the mask has to be defined on that layout. It is the same between regrids,
+    // so this builds it once instead of every step.
+    update_avgdown_masks(crse_lev);
+    const MultiFab& cmskr = *vec_mskr_crse_on_fine[crse_lev];
+    const MultiFab& cmsku = *vec_msku_crse_on_fine[crse_lev];
+    const MultiFab& cmskv = *vec_mskv_crse_on_fine[crse_lev];
 
     // Which mask goes with which field follows the ROMS fine2coarse call sites: rmask for the
     // free surface and the tracers, umask and vmask for the momenta.
@@ -2445,6 +2503,12 @@ REMORA::average_down_masked (int crse_lev, const MultiFab& S_fine, MultiFab& S_c
 
     BoxArray cba = amrex::coarsen(S_fine.boxArray(), ratio);
     MultiFab ctmp(cba, S_fine.DistributionMap(), ncomp, 0);
+
+    // One MFIter indexes all four arrays in the loop below, by local box index, so the masks
+    // have to be distributed exactly as S_fine is. Equal DistributionMappings imply equal box
+    // counts, since a ProcessorMap holds one entry per box.
+    AMREX_ALWAYS_ASSERT(msk_fine.DistributionMap() == S_fine.DistributionMap());
+    AMREX_ALWAYS_ASSERT(cmsk.DistributionMap()     == S_fine.DistributionMap());
 
     for (MFIter mfi(ctmp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -854,29 +854,111 @@ REMORA::set_analytic_vmix(int lev) {
 }
 
 /**
+ * Initialize the land-sea mask on this level.
+ *
+ * This mirrors set_bathymetry: the mask is specified exactly once -- on level 0, or, when a
+ * high-resolution grid covering the entire domain is supplied, at hires_grid_level -- and
+ * every other level is derived from that one specification. No level ever supplies its own
+ * independent mask, so the levels cannot disagree about where the coastline is.
+ *
+ * The hires lane is what lets a refined level carry a better-resolved coastline. It also
+ * closes a gap: with hires_grid_level > 0 the bathymetry already came from the fine grid
+ * while the mask did not, so a run could have high-resolution depths under a coarse
+ * coastline, and needed a level-0 grid file purely to supply that coarse mask.
+ *
  * @param[in   ] lev    level to operate on
  */
 void
-REMORA::set_masks(int lev)
+REMORA::set_masks (int lev)
 {
-    if (solverChoice.mask_type == MaskType::analytic) {
-        prob->init_analytic_masks(lev,geom[lev], solverChoice, *this, *vec_mskr[lev]);
-        calculate_nodal_masks(lev);
-    } else if (solverChoice.mask_type == MaskType::netcdf) {
+    if (solverChoice.mask_type == MaskType::none) {
+        fill_3d_masks(lev);
+        return;
+    }
+
+    if (lev == 0) {
+        // If grid data is not defined on a level > 0 (negative level) then initialize from
+        // the low-resolution grid normally. Otherwise use high-resolution grid data
+        // coarsened down to level 0.
+        if (hires_grid_level < 0) {
+            if (solverChoice.mask_type == MaskType::analytic) {
+                prob->init_analytic_masks(lev,geom[lev], solverChoice, *this, *vec_mskr[lev]);
+                calculate_nodal_masks(lev);
+            } else if (solverChoice.mask_type == MaskType::netcdf) {
 #ifdef REMORA_USE_NETCDF
-        if (lev == 0) {
-            amrex::Print() << "Calling init_masks_from_netcdf level " << lev << std::endl;
-            init_masks_from_netcdf(lev);
-            amrex::Print() << "Masks loaded from netcdf file \n " << std::endl;
+                amrex::Print() << "Calling init_masks_from_netcdf level " << lev << std::endl;
+                init_masks_from_netcdf(lev);
+                amrex::Print() << "Masks loaded from netcdf file \n " << std::endl;
+#endif
+            }
         } else {
+            set_masks_averaged_down(lev);
+        }
+    } else {
+        // If our level is higher than the high resolution grid, interpolate from the level
+        // below. Otherwise, copy over the mask that has been coarsened down.
+        if (lev > hires_grid_level) {
             Real dummy_time = zero;
             FillCoarsePatchPC(lev, dummy_time, vec_mskr[lev].get(), vec_mskr[lev-1].get(),
                     foextrap_bc());
             calculate_nodal_masks(lev);
+        } else {
+            set_masks_averaged_down(lev);
         }
-#endif
     }
     fill_3d_masks(lev);
+}
+
+/**
+ * @param[in   ] lev   level to operate on
+ */
+void
+REMORA::set_masks_averaged_down (int lev) {
+    ParallelCopy(*vec_mskr[lev].get(), *vec_mskr_full_domain[lev].get(), 0, 0, 1,
+            vec_mskr_full_domain[lev]->nGrowVect(),vec_mskr[lev]->nGrowVect());
+    // Deliberately not a FillPatch, unlike the bathymetry and grid-variable analogues: the
+    // interpolation from the coarser level that FillPatch would do for uncovered ghost cells
+    // is not piecewise constant, so it would put fractional values in a field that the rest
+    // of the code compares against 0 and 1 exactly.
+    vec_mskr[lev]->FillBoundary(geom[lev].periodicity());
+    calculate_nodal_masks(lev);
+}
+
+/**
+ * Coarsen the full-domain rho-mask from crse_lev+1 down onto crse_lev, grow cells included,
+ * so that a coarse cell is land only if every one of its fine cells is land.
+ *
+ * This is the counterpart of average_down_with_grow_cells, which cannot be used for a mask:
+ * an arithmetic mean of a partially-wet block gives a fractional value, and the mask has to
+ * stay exactly 0 or 1. Taking "wet if any fine cell is wet" also means the coarse level
+ * never declares land where the fine grid found water, so no water resolved by the fine
+ * grid is lost when the levels are coupled.
+ *
+ * @param[in   ] crse_lev   level to coarsen onto
+ */
+void
+REMORA::coarsen_masks_with_grow_cells (int crse_lev)
+{
+    auto const& crsema = vec_mskr_full_domain[crse_lev]->arrays();
+    auto const& finema = vec_mskr_full_domain[crse_lev+1]->const_arrays();
+    auto ratio = refRatio(crse_lev);
+    // Same grow-cell budget as average_down_with_grow_cells; the mask is cell-centered, so
+    // there is no index-type correction to make.
+    auto nghost_crse = cum_ref_ratios[crse_lev];
+    ParallelFor(*vec_mskr_full_domain[crse_lev], nghost_crse, 1,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+    {
+        const int ii = i * ratio[0];
+        const int jj = j * ratio[1];
+        Real wet = zero;
+        for (int jref = 0; jref < ratio[1]; ++jref) {
+            for (int iref = 0; iref < ratio[0]; ++iref) {
+                wet += amrex::min(one, finema[box_no](ii+iref, jj+jref, k, n));
+            }
+        }
+        crsema[box_no](i,j,k,n) = (wet > zero) ? one : zero;
+    });
+    Gpu::streamSynchronize();
 }
 
 /**
@@ -1342,7 +1424,6 @@ REMORA::init_only (int lev, Real time)
     if (solverChoice.ic_type == IC_Type::analytic) {
         set_grid_scale(lev);
     }
-    set_masks(lev);
 
 #ifdef REMORA_USE_NETCDF
     if (solverChoice.ic_type == IC_Type::netcdf) {
@@ -1540,6 +1621,13 @@ REMORA::init_only (int lev, Real time)
         init_grid_vars_full_domain_from_netcdf();
         amrex::Print() << "Done reading in high resolution bathymetry and grid data" << std::endl;
     }
+    // Keyed off mask_type rather than ic_type: the two are set independently, and a netcdf
+    // run may well ask for no mask at all.
+    if (lev==0 and hires_grid_level > 0 and solverChoice.mask_type == MaskType::netcdf) {
+        amrex::Print() << "Reading high resolution land-sea mask" << std::endl;
+        init_masks_full_domain_from_netcdf();
+        amrex::Print() << "Done reading in high resolution land-sea mask" << std::endl;
+    }
     if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::netcdf) {
         amrex::Print() << "Reading high resolution initial data" << std::endl;
         allocate_init_full_domain();
@@ -1573,12 +1661,21 @@ REMORA::init_only (int lev, Real time)
         init_bathymetry_full_domain_from_analytic();
     }
 
+    if (lev==0 and hires_grid_level > 0 and solverChoice.mask_type == MaskType::analytic) {
+        init_masks_full_domain_from_analytic();
+    }
+
     if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::analytic) {
         allocate_init_full_domain();
         init_full_domain_zeta_from_analytic();
     }
 
     set_bathymetry(lev);
+    // Has to follow set_bathymetry, not precede it as it used to: the mask now has a
+    // hires_grid_level lane of its own, which needs the full-domain data read just above,
+    // and an analytic mask needs the grid coordinates that set_bathymetry -> set_grid_scale
+    // fills on the netcdf path.
+    set_masks(lev);
     set_zeta(lev);
     stretch_transform(lev);
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -975,8 +975,9 @@ REMORA::coarsen_masks_with_grow_cells (int crse_lev)
  *
  * Per level pair, over the region the finer level covers: no coarse water point sits over
  * fine points that are all land, which would leave the average-down nothing to divide by.
- * Coarsening makes that unreachable for cell centers but not for faces, since a coarse u-face
- * is open whenever both its cells are wet and their water can sit away from the shared plane.
+ * Coarsening makes that unreachable for cell centers but not for faces: a coarse u-face is
+ * open whenever both its cells are wet, but only the fine faces in its own plane count, and
+ * the wet fine cells that made those coarse cells wet may all lie elsewhere in their blocks.
  */
 void
 REMORA::check_mask_consistency ()
@@ -1058,34 +1059,68 @@ REMORA::check_mask_consistency ()
             const int rx = ratio[0];
             const int ry = ratio[1];
 
+            // Three passes: a cell-centered box stops at hi, so it would miss the high-side
+            // face that average_down_masked does iterate. nodaltilebox partitions the nodal
+            // range; faces shared between boxes are still counted twice, which can only
+            // inflate a diagnostic.
+            const Long lzero = 0;
+
+            // Cell centers: the whole rx by ry block.
             reduce_op.eval(bx, reduce_data, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 -> ReduceTuple
             {
                 const int ii = i * rx;
                 const int jj = j * ry;
 
-                // Cell centers: the whole rx by ry block.
                 Real wet_r = zero;
                 for (int jref = 0; jref < ry; ++jref) {
                     for (int iref = 0; iref < rx; ++iref) {
                         wet_r += amrex::min(one, fr(ii+iref, jj+jref, k));
                     }
                 }
-                // Faces: only the fine faces lying in the coarse face's plane.
+
+                const bool missed = cr(i,j,k) < zero;
+                return {static_cast<Long>(missed),
+                        static_cast<Long>(!missed && cr(i,j,k) > Real(0.5) && wet_r == zero),
+                        lzero, lzero};
+            });
+
+            // u-faces: only the fine faces in the coarse face's plane. Tests the sentinel too,
+            // so an incomplete copy reports itself instead of failing the > 0.5 test.
+            Box ubx = mfi.nodaltilebox(0); ubx.makeSlab(2,0);
+            reduce_op.eval(ubx, reduce_data, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                -> ReduceTuple
+            {
+                const int ii = i * rx;
+                const int jj = j * ry;
+
                 Real wet_u = zero;
                 for (int jref = 0; jref < ry; ++jref) {
                     wet_u += amrex::min(one, fu(ii, jj+jref, k));
                 }
+
+                const bool missed = cu(i,j,k) < zero;
+                return {static_cast<Long>(missed), lzero,
+                        static_cast<Long>(!missed && cu(i,j,k) > Real(0.5) && wet_u == zero),
+                        lzero};
+            });
+
+            // v-faces, likewise.
+            Box vbx = mfi.nodaltilebox(1); vbx.makeSlab(2,0);
+            reduce_op.eval(vbx, reduce_data, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                -> ReduceTuple
+            {
+                const int ii = i * rx;
+                const int jj = j * ry;
+
                 Real wet_v = zero;
                 for (int iref = 0; iref < rx; ++iref) {
                     wet_v += amrex::min(one, fv(ii+iref, jj, k));
                 }
 
-                const bool missed = cr(i,j,k) < zero;
-                return {static_cast<Long>(missed),
-                        static_cast<Long>(!missed && cr(i,j,k) > Real(0.5) && wet_r == zero),
-                        static_cast<Long>(cu(i,j,k) > Real(0.5) && wet_u == zero),
-                        static_cast<Long>(cv(i,j,k) > Real(0.5) && wet_v == zero)};
+                const bool missed = cv(i,j,k) < zero;
+                return {static_cast<Long>(missed), lzero, lzero,
+                        static_cast<Long>(!missed && cv(i,j,k) > Real(0.5) && wet_v == zero)};
             });
         }
         ReduceTuple hv = reduce_data.value(reduce_op);
@@ -1876,20 +1911,6 @@ REMORA::init_only (int lev, Real time)
         init_riv_pos_from_netcdf(lev);
     }
 
-    if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::netcdf) {
-        amrex::Print() << "Reading high resolution initial data" << std::endl;
-        allocate_init_full_domain();
-        // The initial-state cascade is mask-weighted, so a mask has to exist this high up.
-        ensure_full_domain_masks(hires_init_level);
-        init_data_full_domain_from_netcdf();
-        // Biology source is chosen by remora.biology_ic_type, not by ic_type,
-        // so this goes through the same dispatcher as the per-level path.
-        // Must follow init_data_full_domain_from_netcdf: the analytic biology
-        // profiles read temperature.
-        init_biology_ic_full_domain();
-        init_zeta_full_domain_from_netcdf();
-        amrex::Print() << "Done reading in high resolution initial data" << std::endl;
-    }
 #else
     if (solverChoice.ic_type == IC_Type::netcdf) {
         Abort("Not compiled with NetCDF, but remora.ic_type = netcdf reads initial and grid data from file");
@@ -1906,17 +1927,40 @@ REMORA::init_only (int lev, Real time)
     }
 #endif
 
-    if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::analytic) {
-        allocate_init_full_domain();
-        init_full_domain_zeta_from_analytic();
-    }
-
     set_bathymetry(lev);
     // Has to follow set_bathymetry, not precede it as it used to: the mask now has a
     // hires_grid_level lane of its own, which needs the full-domain data read just above,
     // and an analytic mask needs the grid coordinates that set_bathymetry -> set_grid_scale
     // fills on the netcdf path.
     set_masks(lev);
+
+    // Has to sit between set_masks and set_zeta. After set_masks, since
+    // ensure_full_domain_masks seeds level 0 from vec_mskr[0], and init_masks' all-water
+    // placeholder would reduce the weighting below to a plain mean. Before set_zeta, which
+    // reads the vec_zeta_full_domain this fills.
+    if (lev==0 and hires_init_level > 0) {
+        if (solverChoice.ic_type == IC_Type::netcdf) {
+#ifdef REMORA_USE_NETCDF
+            amrex::Print() << "Reading high resolution initial data" << std::endl;
+            allocate_init_full_domain();
+            // The initial-state cascade is mask-weighted, so a mask has to exist this high up.
+            ensure_full_domain_masks(hires_init_level);
+            init_data_full_domain_from_netcdf();
+            // Biology source is chosen by remora.biology_ic_type, not by ic_type,
+            // so this goes through the same dispatcher as the per-level path.
+            // Must follow init_data_full_domain_from_netcdf: the analytic biology
+            // profiles read temperature.
+            init_biology_ic_full_domain();
+            init_zeta_full_domain_from_netcdf();
+            amrex::Print() << "Done reading in high resolution initial data" << std::endl;
+#endif
+        } else if (solverChoice.ic_type == IC_Type::analytic) {
+            allocate_init_full_domain();
+            ensure_full_domain_masks(hires_init_level);
+            init_full_domain_zeta_from_analytic();
+        }
+    }
+
     set_zeta(lev);
     stretch_transform(lev);
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -969,15 +969,9 @@ REMORA::coarsen_masks_with_grow_cells (int crse_lev)
  * Check the land-sea masks for what the rest of the code relies on. Only runs when
  * remora.check_mask_consistency is set; remora.mask_consistency picks abort or warn.
  *
- * Per level: the masks hold only the values they are meant to, since the plotfile writer
- * decides what to blank by comparing them against 0 exactly, and no water cell has a
- * non-positive depth, which stretch_transform turns into quiet garbage rather than a crash.
- *
- * Per level pair, over the region the finer level covers: no coarse water point sits over
- * fine points that are all land, which would leave the average-down nothing to divide by.
- * Coarsening makes that unreachable for cell centers but not for faces: a coarse u-face is
- * open whenever both its cells are wet, but only the fine faces in its own plane count, and
- * the wet fine cells that made those coarse cells wet may all lie elsewhere in their blocks.
+ * Per level, that the masks hold only the values they are meant to and that no water cell has
+ * a non-positive depth. Per level pair, over the region the finer level covers, that no coarse
+ * water point sits over fine points that are all land.
  */
 void
 REMORA::check_mask_consistency ()
@@ -989,7 +983,10 @@ REMORA::check_mask_consistency ()
 
     Long nbad_val = 0, nbad_h = 0, ndry_r = 0, ndry_u = 0, ndry_v = 0, nmissed = 0;
 
-    // Per-level checks
+    // Per-level checks. Mask values matter because the plotfile writer decides what to blank
+    // by comparing them against 0 exactly, so a fractional mask stops masking; a water cell
+    // with h <= 0 matters because stretch_transform divides by hc + h, giving quiet garbage
+    // rather than a crash.
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         ReduceOps<ReduceOpSum, ReduceOpSum> reduce_op;
@@ -1024,7 +1021,12 @@ REMORA::check_mask_consistency ()
         nbad_h   += amrex::get<1>(hv);
     }
 
-    // Level-pair checks, over the region the finer level covers
+    // Level-pair checks, over the region the finer level covers. A coarse water point over
+    // nothing but land would leave the average-down nothing to divide by. Coarsening makes
+    // that unreachable for cell centers -- a wet coarse cell is wet because some fine cell in
+    // its own block is -- but not for faces: a coarse u-face is open whenever both its cells
+    // are wet, only the fine faces in its own plane count, and the wet fine cells that made
+    // those coarse cells wet may all lie elsewhere in their blocks.
     for (int crse_lev = 0; crse_lev < finest_level; ++crse_lev)
     {
         const int flev = crse_lev + 1;
@@ -1191,10 +1193,8 @@ REMORA::check_mask_consistency ()
  *
  * Averaging every fine cell would mix in whatever the grid file holds under land, which on a
  * ROMS grid is a fill value with no physical meaning. A wet coarse cell should take the depth
- * of the water under it. Where every fine cell is land there is none to average, but h still
- * has to hold something, so that falls back to the plain mean -- which also makes an all-wet
- * or all-land group reproduce average_down_with_grow_cells bit for bit. See
- * REMORA_MaskedAverageDown.H for why the arithmetic is written the way it is.
+ * of the water under it. See REMORA_MaskedAverageDown.H for why the arithmetic is written the
+ * way it is.
  *
  * @param[in   ] crse_lev   level to coarsen onto
  */
@@ -1222,6 +1222,9 @@ REMORA::coarsen_bathymetry_with_grow_cells (int crse_lev)
                 sum_all += hf;
             }
         }
+        // All-land: no water to average, but h still has to hold something, so fall back to
+        // the plain mean. That also makes an all-wet or all-land group reproduce
+        // average_down_with_grow_cells bit for bit.
         crsema[box_no](i,j,k,n) = (den > zero)
                                 ? num * (one/den)
                                 : sum_all * (one/Real(ratio[0]*ratio[1]));
@@ -2456,8 +2459,7 @@ REMORA::clear_avgdown_masks (int lev)
  *
  * The masks are a function of position alone, so between regrids this is the same answer every
  * step; building it once turns three allocations and three ParallelCopy calls per step into
- * three per regrid. clear_avgdown_masks drops the cache when a mask is rewritten, and the
- * layout comparison below catches anything that reaches here without going through it.
+ * three per regrid.
  *
  * @param[in   ] crse_lev   coarse level of the pair
  */
@@ -2471,6 +2473,8 @@ REMORA::update_avgdown_masks (int crse_lev)
     const BoxArray cba = amrex::coarsen(vec_mskr[flev]->boxArray(), ratio);
     const DistributionMapping& dmf = vec_mskr[flev]->DistributionMap();
 
+    // clear_avgdown_masks drops the cache whenever a mask is rewritten; this catches anything
+    // that gets here without having gone through it, by rebuilding when the layout has moved.
     if (vec_mskr_crse_on_fine[crse_lev] &&
         vec_mskr_crse_on_fine[crse_lev]->boxArray() == cba &&
         vec_mskr_crse_on_fine[crse_lev]->DistributionMap() == dmf) {
@@ -2526,8 +2530,7 @@ REMORA::AverageDownTo (int crse_lev)
  *
  * Follows amrex::average_down's non-MFIter-safe branch, since coarsen(grids[flev]) does not
  * match grids[crse_lev] in general: compute onto a temporary on the coarsened-fine layout,
- * then ParallelCopy that onto the coarse level. The periodicity arguments match what
- * average_down and average_down_faces pass.
+ * then ParallelCopy that onto the coarse level.
  *
  * @param[in   ] crse_lev   level to average down to
  * @param[in   ] S_fine     fine-level field
@@ -2576,6 +2579,9 @@ REMORA::average_down_masked (int crse_lev, const MultiFab& S_fine, MultiFab& S_c
     }
     Gpu::streamSynchronize();
 
+    // Periodicity arguments as amrex::average_down and average_down_faces pass them: the
+    // cell-centered copy takes none, the face copy needs it so shared faces across a periodic
+    // boundary agree.
     if (face_dir < 0) {
         S_crse.ParallelCopy(ctmp, 0, 0, ncomp);
     } else {

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -2587,7 +2587,7 @@ REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<Multi
                 MultiFab& dst = (which == 0) ? fmsk : cmsk;
                 const MultiFab& src = *vec_mskr_full_domain[mlev];
                 // One ring narrower than the rho mask, since the stencil reaches back a cell.
-                const IntVect ng = max(src.nGrowVect() - IntVect(1,1,0), IntVect(0));
+                const IntVect ng = max(src.nGrowVect() - nd, IntVect(0));
                 dst.define(convert(src.boxArray(), nd), src.DistributionMap(), 1, ng);
                 dst.setVal(one);
                 for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
@@ -2607,8 +2607,7 @@ REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<Multi
                                          : vec_mskr_full_domain[crse_lev+1]->const_arrays();
         auto const& cmskma = (idir >= 0) ? cmsk.const_arrays()
                                          : vec_mskr_full_domain[crse_lev]->const_arrays();
-        const int ncomp = (idir >= 0) ? 1 : vec_mf[crse_lev]->nComp();
-        ParallelFor(*vec_mf[crse_lev], nghost_crse, ncomp,
+        ParallelFor(*vec_mf[crse_lev], nghost_crse, vec_mf[crse_lev]->nComp(),
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             if (idir < 0) {
@@ -2630,13 +2629,13 @@ REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<Multi
             amrex_avgdown(i,j,k,n,crsema[box_no],finema[box_no],0,0,ref_ratio_crse);
         });
     } else if (index_type[0]==1 and index_type[1]==0) {
-        ParallelFor(*vec_mf[crse_lev], nghost_crse, 1,
+        ParallelFor(*vec_mf[crse_lev], nghost_crse, vec_mf[crse_lev]->nComp(),
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             amrex_avgdown_faces(i,j,k,n,crsema[box_no],finema[box_no],0,0,ref_ratio_crse,0);
         });
     } else if (index_type[0]==0 and index_type[1]==1) {
-        ParallelFor(*vec_mf[crse_lev], nghost_crse, 1,
+        ParallelFor(*vec_mf[crse_lev], nghost_crse, vec_mf[crse_lev]->nComp(),
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             amrex_avgdown_faces(i,j,k,n,crsema[box_no],finema[box_no],0,0,ref_ratio_crse,1);

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1888,6 +1888,8 @@ REMORA::init_only (int lev, Real time)
     if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::netcdf) {
         amrex::Print() << "Reading high resolution initial data" << std::endl;
         allocate_init_full_domain();
+        // The initial-state cascade is mask-weighted, so a mask has to exist this high up.
+        ensure_full_domain_masks(hires_init_level);
         init_data_full_domain_from_netcdf();
         // Biology source is chosen by remora.biology_ic_type, not by ic_type,
         // so this goes through the same dispatcher as the per-level path.
@@ -2487,17 +2489,155 @@ REMORA::average_down_masked (int crse_lev, const MultiFab& S_fine, MultiFab& S_c
 }
 
 /**
- * @param[in   ] crse_lev   level to average data down to
- * @param[inout] vec_mf     vector over levels of multifabs containing data to average
+ * Inject the full-domain rho-mask from fine_lev-1 up onto fine_lev, grow cells included.
+ *
+ * Piecewise constant, which is the rule set_masks already uses for a level above the one the
+ * mask was specified on. Nothing finer is known there, so refining cannot add coastline.
+ *
+ * @param[in   ] fine_lev   level to inject onto
  */
 void
-REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<MultiFab>>& vec_mf)
+REMORA::refine_masks_with_grow_cells (int fine_lev)
+{
+    auto const& finema = vec_mskr_full_domain[fine_lev]->arrays();
+    auto const& crsema = vec_mskr_full_domain[fine_lev-1]->const_arrays();
+    auto ratio = refRatio(fine_lev-1);
+    auto nghost_fine = cum_ref_ratios[fine_lev];
+    ParallelFor(*vec_mskr_full_domain[fine_lev], nghost_fine, 1,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+    {
+        // amrex::coarsen floors rather than truncating, which is what the negative indices of
+        // the grow cells need.
+        finema[box_no](i,j,k,n) = crsema[box_no](amrex::coarsen(i, ratio[0]),
+                                                amrex::coarsen(j, ratio[1]), k, n);
+    });
+    Gpu::streamSynchronize();
+}
+
+/**
+ * Make sure the full-domain rho-mask exists on levels 0 through top_lev.
+ *
+ * The mask is specified once and every other level derived from it, so this only fills what
+ * the hires_grid_level cascade has not: levels above it, by injection, and level 0 itself when
+ * there is no high-resolution grid at all and the mask was given per-level instead.
+ *
+ * @param[in   ] top_lev   highest level that needs a mask
+ */
+void
+REMORA::ensure_full_domain_masks (int top_lev)
+{
+    if (solverChoice.mask_type == MaskType::none || top_lev <= 0) { return; }
+
+    // Levels up to hires_grid_level were coarsened down from it already.
+    const int have = (hires_grid_level > 0) ? hires_grid_level : 0;
+    if (top_lev <= have) { return; }
+
+    BoxArray ba;
+    ba.define(makeSlab(geom[0].Domain(),2,0));
+    DistributionMapping dm(ba);
+    auto mskr_growvect = vec_mskr[0]->nGrowVect();
+
+    if (hires_grid_level < 0) {
+        // No high-resolution grid, so the specification lives on level 0. Seed from it.
+        vec_mskr_full_domain[0].reset(new MultiFab(ba, dm, 1, IntVect(1,1,0)));
+        vec_mskr_full_domain[0]->setVal(one);
+        ParallelCopy(*vec_mskr_full_domain[0].get(), *vec_mskr[0].get(), 0, 0, 1,
+                vec_mskr[0]->nGrowVect(), vec_mskr_full_domain[0]->nGrowVect());
+    }
+
+    for (int lev = 1; lev <= top_lev; lev++) {
+        ba = ba.refine(refRatio(lev-1));
+        if (lev <= have) { continue; }
+        vec_mskr_full_domain[lev].reset(new MultiFab(ba, dm, 1,
+                    max(cum_ref_ratios[lev], mskr_growvect)));
+        vec_mskr_full_domain[lev]->setVal(one);
+        refine_masks_with_grow_cells(lev);
+    }
+}
+
+/**
+ * Average a full-domain field from crse_lev+1 onto crse_lev, grow cells included.
+ *
+ * With use_mask, the mask-weighted mean of REMORAMaskedAvgDown is used instead of the plain
+ * one, so that the initial state on a coarse cell only partly covered by water comes from that
+ * water rather than from a mean diluted by land. That is the same formula AverageDownTo applies
+ * every step, so the initial and the running state agree on what a land point holds.
+ *
+ * Leave use_mask off for grid metrics: a cell size is perfectly well defined under land, and
+ * masking pm/pn would corrupt it.
+ *
+ * @param[in   ] crse_lev   level to average data down to
+ * @param[inout] vec_mf     vector over levels of multifabs containing data to average
+ * @param[in   ] use_mask   weight by the land/sea mask rather than averaging the whole block
+ */
+void
+REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<MultiFab>>& vec_mf,
+                                      bool use_mask)
 {
     auto const& crsema = vec_mf[crse_lev]->arrays();
     auto const& finema = vec_mf[crse_lev+1]->const_arrays();
     auto ref_ratio_crse = refRatio(crse_lev);
     auto index_type = (vec_mf[crse_lev]->boxArray().ixType()).toIntVect();
     auto nghost_crse = cum_ref_ratios[crse_lev] - index_type;
+
+    const bool masked = use_mask && (solverChoice.mask_type != MaskType::none);
+    if (masked) {
+        // The full-domain arrays are one box per level on a matching DistributionMapping, so an
+        // MFIter over one indexes the other. Assert it rather than assume it.
+        AMREX_ALWAYS_ASSERT(vec_mskr_full_domain[crse_lev] && vec_mskr_full_domain[crse_lev+1]);
+        AMREX_ALWAYS_ASSERT(vec_mskr_full_domain[crse_lev]->boxArray().size() ==
+                            vec_mf[crse_lev]->boxArray().size());
+        AMREX_ALWAYS_ASSERT(vec_mskr_full_domain[crse_lev]->DistributionMap() ==
+                            vec_mf[crse_lev]->DistributionMap());
+
+        // Face masks are derived here rather than stored: nothing else needs them, and a
+        // derived one cannot drift out of sync with the rho mask it comes from. The rule is
+        // ROMS set_masks.F's, msku = mskr(i-1,j)*mskr(i,j).
+        const int idir = (index_type[0]==1) ? 0 : ((index_type[1]==1) ? 1 : -1);
+        MultiFab fmsk, cmsk;
+        if (idir >= 0) {
+            const IntVect nd = (idir == 0) ? IntVect(1,0,0) : IntVect(0,1,0);
+            for (int which = 0; which < 2; ++which) {
+                const int mlev = crse_lev + 1 - which;
+                MultiFab& dst = (which == 0) ? fmsk : cmsk;
+                const MultiFab& src = *vec_mskr_full_domain[mlev];
+                // One ring narrower than the rho mask, since the stencil reaches back a cell.
+                const IntVect ng = max(src.nGrowVect() - IntVect(1,1,0), IntVect(0));
+                dst.define(convert(src.boxArray(), nd), src.DistributionMap(), 1, ng);
+                dst.setVal(one);
+                for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                    const Box& bx = mfi.growntilebox();
+                    Array4<      Real> const& mf = dst.array(mfi);
+                    Array4<const Real> const& mr = src.const_array(mfi);
+                    const int l_idir = idir;
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                    {
+                        mf(i,j,k) = (l_idir == 0) ? mr(i-1,j,0) * mr(i,j,0)
+                                                  : mr(i,j-1,0) * mr(i,j,0);
+                    });
+                }
+            }
+        }
+        auto const& fmskma = (idir >= 0) ? fmsk.const_arrays()
+                                         : vec_mskr_full_domain[crse_lev+1]->const_arrays();
+        auto const& cmskma = (idir >= 0) ? cmsk.const_arrays()
+                                         : vec_mskr_full_domain[crse_lev]->const_arrays();
+        const int ncomp = (idir >= 0) ? 1 : vec_mf[crse_lev]->nComp();
+        ParallelFor(*vec_mf[crse_lev], nghost_crse, ncomp,
+                [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+        {
+            if (idir < 0) {
+                REMORAMaskedAvgDown::avgdown_masked(i,j,k,n,crsema[box_no],finema[box_no],
+                        fmskma[box_no],cmskma[box_no],0,0,ref_ratio_crse);
+            } else {
+                REMORAMaskedAvgDown::avgdown_faces_masked(i,j,k,n,crsema[box_no],finema[box_no],
+                        fmskma[box_no],cmskma[box_no],0,0,ref_ratio_crse,idir);
+            }
+        });
+        Gpu::streamSynchronize();
+        return;
+    }
+
     if (index_type[0]==0 and index_type[1]==0) {
         ParallelFor(*vec_mf[crse_lev], nghost_crse, vec_mf[crse_lev]->nComp(),
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -871,7 +871,7 @@ REMORA::set_analytic_vmix(int lev) {
 void
 REMORA::set_masks (int lev)
 {
-    // Ahead of the mask_type == none return as well: that lane still fills the masks, and
+    // Ahead of the mask_type == none return as well: that branch still fills the masks, and
     // AverageDownTo still reads them, so its cached copies go stale here too.
     clear_avgdown_masks(lev);
 
@@ -1933,7 +1933,7 @@ REMORA::init_only (int lev, Real time)
 
     set_bathymetry(lev);
     // Has to follow set_bathymetry, not precede it as it used to: the mask now has a
-    // hires_grid_level lane of its own, which needs the full-domain data read just above,
+    // hires_grid_level path of its own, which needs the full-domain data read just above,
     // and an analytic mask needs the grid coordinates that set_bathymetry -> set_grid_scale
     // fills on the netcdf path.
     set_masks(lev);

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -95,7 +95,7 @@ enum class MaskType {
 
 /** \brief what to do when a level's mask disagrees with the level above it */
 enum class MaskConsistency {
-    abort, warn, ignore
+    abort, warn
 };
 
 /** \brief harmonic mixing; which surfaces to calculate along */
@@ -561,14 +561,17 @@ struct SolverChoice {
             amrex::Abort("Don't know this mask_type");
         }
 
+        // Off by default: the masks are derived from one specification, so this validates
+        // that machinery rather than user input. Worth paying for in the test suite and when
+        // bringing up a new grid, not in production.
+        pp.queryAdd("check_mask_consistency", do_check_mask_consistency);
+
         static std::string mask_consistency_string = "abort";
         pp.queryAdd("mask_consistency", mask_consistency_string);
         if (amrex::toLower(mask_consistency_string) == "abort") {
             mask_consistency = MaskConsistency::abort;
         } else if (amrex::toLower(mask_consistency_string) == "warn") {
             mask_consistency = MaskConsistency::warn;
-        } else if (amrex::toLower(mask_consistency_string) == "ignore") {
-            mask_consistency = MaskConsistency::ignore;
         } else {
             amrex::Abort("Don't know this mask_consistency");
         }
@@ -925,7 +928,8 @@ struct SolverChoice {
     // Land/sea mask type
     MaskType mask_type;
 
-    // What to do when the land/sea masks on two levels disagree
+    // Whether to validate the land/sea masks at all, and what to do when they fail
+    bool do_check_mask_consistency = false;
     MaskConsistency mask_consistency;
 
     // Mixing type and parameters

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -93,6 +93,11 @@ enum class MaskType {
     none, analytic, netcdf
 };
 
+/** \brief what to do when a level's mask disagrees with the level above it */
+enum class MaskConsistency {
+    abort, warn, ignore
+};
+
 /** \brief harmonic mixing; which surfaces to calculate along */
 enum class HarmonicMixingType {
     s, geopotential
@@ -556,6 +561,18 @@ struct SolverChoice {
             amrex::Abort("Don't know this mask_type");
         }
 
+        static std::string mask_consistency_string = "abort";
+        pp.queryAdd("mask_consistency", mask_consistency_string);
+        if (amrex::toLower(mask_consistency_string) == "abort") {
+            mask_consistency = MaskConsistency::abort;
+        } else if (amrex::toLower(mask_consistency_string) == "warn") {
+            mask_consistency = MaskConsistency::warn;
+        } else if (amrex::toLower(mask_consistency_string) == "ignore") {
+            mask_consistency = MaskConsistency::ignore;
+        } else {
+            amrex::Abort("Don't know this mask_consistency");
+        }
+
         static std::string bottom_stress_type_string = "linear";
         pp.queryAdd("bottom_stress_type", bottom_stress_type_string);
         if (amrex::toLower(bottom_stress_type_string) == "linear") {
@@ -907,6 +924,9 @@ struct SolverChoice {
 
     // Land/sea mask type
     MaskType mask_type;
+
+    // What to do when the land/sea masks on two levels disagree
+    MaskConsistency mask_consistency;
 
     // Mixing type and parameters
     VertMixingType vert_mixing_type;

--- a/Source/TimeIntegration/REMORA_TimeStep.cpp
+++ b/Source/TimeIntegration/REMORA_TimeStep.cpp
@@ -28,6 +28,9 @@ REMORA::timeStep (int lev, Real time, int iteration)
                 int old_finest = finest_level;
                 regrid(lev, time);
 
+                // The refined footprint moved, so the level pairs are new
+                check_mask_consistency();
+
 #ifdef REMORA_USE_PARTICLES
                 if (finest_level != old_finest) {
                     particleData.Redistribute();

--- a/Source/TimeIntegration/REMORA_TimeStepML.cpp
+++ b/Source/TimeIntegration/REMORA_TimeStepML.cpp
@@ -37,6 +37,9 @@ REMORA::timeStepML (Real time, int /*iteration*/)
                     int old_finest = finest_level;
                     regrid(lev, time);
 
+                // The refined footprint moved, so the level pairs are new
+                check_mask_consistency();
+
                     // Mark that we have regridded this level already
                     for (int k = lev; k <= finest_level; ++k) {
                         last_regrid_step[k] = istep[k];

--- a/Source/TimeIntegration/REMORA_TimeStepML.cpp
+++ b/Source/TimeIntegration/REMORA_TimeStepML.cpp
@@ -17,7 +17,6 @@ REMORA::timeStepML (Real time, int /*iteration*/)
     }
 #endif
 
-    // HACK HACK so lev is defined and compiler won't complain, but always say regrid_int=-1
     for (int lev=0; lev <= finest_level;lev++) {
         if (regrid_int > 0)  // We may need to regrid
         {
@@ -37,8 +36,8 @@ REMORA::timeStepML (Real time, int /*iteration*/)
                     int old_finest = finest_level;
                     regrid(lev, time);
 
-                // The refined footprint moved, so the level pairs are new
-                check_mask_consistency();
+                    // The refined footprint moved, so the level pairs are new
+                    check_mask_consistency();
 
                     // Mark that we have regridded this level already
                     for (int k = lev; k <= finest_level; ++k) {

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -1,2 +1,3 @@
 CEXE_headers += REMORA_DateClock.H
 CEXE_headers += REMORA_DepthStretchTransform.H
+CEXE_headers += REMORA_MaskedAverageDown.H

--- a/Source/Utils/REMORA_MaskedAverageDown.H
+++ b/Source/Utils/REMORA_MaskedAverageDown.H
@@ -12,31 +12,27 @@
  * Ported from ROMS fine2coarse2d/fine2coarse3d in Nonlinear/nesting.F, the AreaAvg = .FALSE.
  * branch that every call site there uses:
  *
- *     num  = sum over the block of (fine value * fine mask)
- *     den  = sum over the block of min(1, fine mask)
+ *     num  = sum of (fine value * fine mask) over the fine points under the coarse one
+ *     den  = sum of min(1, fine mask) over the same
  *     crse = num/den * coarse mask
  *
- * The divisor is the count of WET fine points, not the number of points in the block, so a
- * coarse point that is only partly covered by water takes the mean of the water under it
- * rather than a value diluted toward zero by land. That is not conservative; ROMS makes the
- * same trade, on the grounds that a coastal tracer value pulled toward zero is worse than a
- * small loss of conservation. The coarse mask has the final say on wet or dry.
+ * Dividing by the count of wet fine points rather than by how many there are means a coarse
+ * point only partly covered by water takes the mean of that water, not a value diluted toward
+ * zero by land. That is not conservative; ROMS makes the same trade deliberately. The coarse
+ * mask has the final say on wet or dry.
  *
- * den == 0 under a wet coarse point would leave nothing to divide by. That cannot happen
- * once check_mask_consistency passes, so the kernels write zero and leave the diagnosis to
- * it rather than trying to report from a device kernel.
+ * den == 0 under a wet coarse point cannot happen once check_mask_consistency passes, so the
+ * kernels write zero rather than trying to diagnose it from a device kernel.
  *
- * A fully wet block has to reproduce amrex_avgdown and amrex_avgdown_faces bit for bit, or
- * every multilevel answer moves in its last bit. That is why the block is walked in the same
- * order AMReX walks it, why the mask multiplies the value before it is accumulated (m is
- * exactly 1.0 there, and x * 1.0 == x), and why the division is written as a multiplication
- * by the reciprocal (den is then exactly the point count, so 1.0/den is exactly AMReX's
- * volfrac). Writing num/den instead would differ in the last bit.
+ * Where every fine point is wet this has to reproduce amrex_avgdown and amrex_avgdown_faces
+ * bit for bit, or every multilevel answer moves in its last bit. Hence AMReX's iteration
+ * order, the mask multiplying the value before it is accumulated (x * 1.0 == x), and the
+ * division written as a multiplication by the reciprocal, which is exactly AMReX's volfrac.
+ * Writing num/den instead would differ in the last bit.
  */
 namespace REMORAMaskedAvgDown {
 
-/** Cell-centered fields: the whole ratio[0] x ratio[1] x ratio[2] block. The mask is 2D and
- *  is read on its z-slab. */
+/** Cell-centered fields: every fine cell under the coarse one. The mask is 2D, read at k=0. */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void avgdown_masked (int i, int j, int k, int n,
                      amrex::Array4<amrex::Real>       const& crse,
@@ -68,8 +64,8 @@ void avgdown_masked (int i, int j, int k, int n,
                         : Real(0.0);
 }
 
-/** Face-centered fields: only the fine faces lying in the coarse face's own plane, which is
- *  the stencil amrex_avgdown_faces uses. "Wet" then means the flow really does cross here. */
+/** Face-centered fields: only the fine faces in the coarse face's own plane, the stencil
+ *  amrex_avgdown_faces uses, so "wet" means the flow really does cross here. */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void avgdown_faces_masked (int i, int j, int k, int n,
                            amrex::Array4<amrex::Real>       const& crse,

--- a/Source/Utils/REMORA_MaskedAverageDown.H
+++ b/Source/Utils/REMORA_MaskedAverageDown.H
@@ -1,0 +1,122 @@
+#ifndef REMORA_MASKED_AVERAGE_DOWN_H_
+#define REMORA_MASKED_AVERAGE_DOWN_H_
+
+#include <AMReX_Algorithm.H>
+#include <AMReX_Array4.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_REAL.H>
+
+/**
+ * Two-way nesting's fine-to-coarse update, weighted by the land/sea mask.
+ *
+ * Ported from ROMS fine2coarse2d/fine2coarse3d in Nonlinear/nesting.F, the AreaAvg = .FALSE.
+ * branch that every call site there uses:
+ *
+ *     num  = sum over the block of (fine value * fine mask)
+ *     den  = sum over the block of min(1, fine mask)
+ *     crse = num/den * coarse mask
+ *
+ * The divisor is the count of WET fine points, not the number of points in the block, so a
+ * coarse point that is only partly covered by water takes the mean of the water under it
+ * rather than a value diluted toward zero by land. That is not conservative; ROMS makes the
+ * same trade, on the grounds that a coastal tracer value pulled toward zero is worse than a
+ * small loss of conservation. The coarse mask has the final say on wet or dry.
+ *
+ * den == 0 under a wet coarse point would leave nothing to divide by. That cannot happen
+ * once check_mask_consistency passes, so the kernels write zero and leave the diagnosis to
+ * it rather than trying to report from a device kernel.
+ *
+ * A fully wet block has to reproduce amrex_avgdown and amrex_avgdown_faces bit for bit, or
+ * every multilevel answer moves in its last bit. That is why the block is walked in the same
+ * order AMReX walks it, why the mask multiplies the value before it is accumulated (m is
+ * exactly 1.0 there, and x * 1.0 == x), and why the division is written as a multiplication
+ * by the reciprocal (den is then exactly the point count, so 1.0/den is exactly AMReX's
+ * volfrac). Writing num/den instead would differ in the last bit.
+ */
+namespace REMORAMaskedAvgDown {
+
+/** Cell-centered fields: the whole ratio[0] x ratio[1] x ratio[2] block. The mask is 2D and
+ *  is read on its z-slab. */
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void avgdown_masked (int i, int j, int k, int n,
+                     amrex::Array4<amrex::Real>       const& crse,
+                     amrex::Array4<amrex::Real const> const& fine,
+                     amrex::Array4<amrex::Real const> const& fmsk,
+                     amrex::Array4<amrex::Real const> const& cmsk,
+                     int ccomp, int fcomp, amrex::IntVect const& ratio) noexcept
+{
+    using amrex::Real;
+    const int facx = ratio[0];
+    const int facy = ratio[1];
+    const int facz = ratio[2];
+    const int ii = i*facx;
+    const int jj = j*facy;
+    const int kk = k*facz;
+
+    Real num = Real(0.0);
+    Real den = Real(0.0);
+    for (int kref = 0; kref < facz; ++kref) {
+    for (int jref = 0; jref < facy; ++jref) {
+    for (int iref = 0; iref < facx; ++iref) {
+        const Real m = amrex::min(Real(1.0), fmsk(ii+iref,jj+jref,0));
+        num += fine(ii+iref,jj+jref,kk+kref,n+fcomp) * m;
+        den += m;
+    }}}
+
+    crse(i,j,k,n+ccomp) = (den > Real(0.0))
+                        ? num * (Real(1.0)/den) * cmsk(i,j,0)
+                        : Real(0.0);
+}
+
+/** Face-centered fields: only the fine faces lying in the coarse face's own plane, which is
+ *  the stencil amrex_avgdown_faces uses. "Wet" then means the flow really does cross here. */
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void avgdown_faces_masked (int i, int j, int k, int n,
+                           amrex::Array4<amrex::Real>       const& crse,
+                           amrex::Array4<amrex::Real const> const& fine,
+                           amrex::Array4<amrex::Real const> const& fmsk,
+                           amrex::Array4<amrex::Real const> const& cmsk,
+                           int ccomp, int fcomp, amrex::IntVect const& ratio, int idir) noexcept
+{
+    using amrex::Real;
+    const int facx = ratio[0];
+    const int facy = ratio[1];
+    const int facz = ratio[2];
+    const int ii = i*facx;
+    const int jj = j*facy;
+    const int kk = k*facz;
+
+    Real num = Real(0.0);
+    Real den = Real(0.0);
+
+    if (idir == 0) {
+        for (int kref = 0; kref < facz; ++kref) {
+        for (int jref = 0; jref < facy; ++jref) {
+            const Real m = amrex::min(Real(1.0), fmsk(ii,jj+jref,0));
+            num += fine(ii,jj+jref,kk+kref,n+fcomp) * m;
+            den += m;
+        }}
+    } else if (idir == 1) {
+        for (int kref = 0; kref < facz; ++kref) {
+        for (int iref = 0; iref < facx; ++iref) {
+            const Real m = amrex::min(Real(1.0), fmsk(ii+iref,jj,0));
+            num += fine(ii+iref,jj,kk+kref,n+fcomp) * m;
+            den += m;
+        }}
+    } else {
+        for (int jref = 0; jref < facy; ++jref) {
+        for (int iref = 0; iref < facx; ++iref) {
+            const Real m = amrex::min(Real(1.0), fmsk(ii+iref,jj+jref,0));
+            num += fine(ii+iref,jj+jref,kk,n+fcomp) * m;
+            den += m;
+        }}
+    }
+
+    crse(i,j,k,n+ccomp) = (den > Real(0.0))
+                        ? num * (Real(1.0)/den) * cmsk(i,j,0)
+                        : Real(0.0);
+}
+
+} // namespace REMORAMaskedAvgDown
+
+#endif

--- a/Source/Utils/REMORA_MaskedAverageDown.H
+++ b/Source/Utils/REMORA_MaskedAverageDown.H
@@ -21,14 +21,8 @@
  * zero by land. That is not conservative; ROMS makes the same trade deliberately. The coarse
  * mask has the final say on wet or dry.
  *
- * den == 0 under a wet coarse point cannot happen once check_mask_consistency passes, so the
- * kernels write zero rather than trying to diagnose it from a device kernel.
- *
- * Where every fine point is wet this has to reproduce amrex_avgdown and amrex_avgdown_faces
- * bit for bit, or every multilevel answer moves in its last bit. Hence AMReX's iteration
- * order, the mask multiplying the value before it is accumulated (x * 1.0 == x), and the
- * division written as a multiplication by the reciprocal, which is exactly AMReX's volfrac.
- * Writing num/den instead would differ in the last bit.
+ * Where every fine point is wet these have to reproduce amrex_avgdown and amrex_avgdown_faces
+ * bit for bit, or every existing multilevel answer moves in its last bit.
  */
 namespace REMORAMaskedAvgDown {
 
@@ -51,6 +45,8 @@ void avgdown_masked (int i, int j, int k, int n,
 
     Real num = Real(0.0);
     Real den = Real(0.0);
+    // AMReX's loop order, and the mask multiplying the value before it is accumulated rather
+    // than after (x * 1.0 == x), are what make the all-wet case bit-identical to amrex_avgdown.
     for (int kref = 0; kref < facz; ++kref) {
     for (int jref = 0; jref < facy; ++jref) {
     for (int iref = 0; iref < facx; ++iref) {
@@ -59,6 +55,9 @@ void avgdown_masked (int i, int j, int k, int n,
         den += m;
     }}}
 
+    // Multiplication by the reciprocal, not num/den: this is AMReX's volfrac, and dividing
+    // would differ in the last bit. den == 0 under a wet coarse point cannot happen once
+    // check_mask_consistency passes, so write zero rather than diagnose it from a kernel.
     crse(i,j,k,n+ccomp) = (den > Real(0.0))
                         ? num * (Real(1.0)/den) * cmsk(i,j,0)
                         : Real(0.0);
@@ -108,6 +107,7 @@ void avgdown_faces_masked (int i, int j, int k, int n,
         }}
     }
 
+    // As in avgdown_masked: reciprocal rather than divide, and zero when nothing is wet.
     crse(i,j,k,n+ccomp) = (den > Real(0.0))
                         ? num * (Real(1.0)/den) * cmsk(i,j,0)
                         : Real(0.0);

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -236,7 +236,7 @@ function(add_test_0 TEST_NAME TEST_EXE PLTFILE)
 
     set(FCOMPARE_TOLERANCE "-r 1e-14 --abs_tol 1.0e-14")
     set(FCOMPARE_FLAGS "-a ${FCOMPARE_TOLERANCE}")
-    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i erf.input_sounding_file=${CURRENT_TEST_BINARY_DIR}/input_sounding ${RUNTIME_OPTIONS} > ${TEST_NAME}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${CURRENT_TEST_BINARY_DIR}/plt00000 ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
+    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${CURRENT_TEST_BINARY_DIR}/plt00000 ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
 
     add_test(${TEST_NAME} ${test_command})
     set_tests_properties(${TEST_NAME}
@@ -304,6 +304,13 @@ add_test_r(DogboneAnalytic_MLquad       "remora_exec" "plt_ml_quad00010")
 
 add_test_r_gold(Channel_Test_hires       "remora_exec" "plt00010"    Channel_Test)
 add_test_r_gold(DogboneAnalytic_MLhires  "remora_exec" "plt_ml00010" DogboneAnalytic_MLvel)
+
+# The only lanes with a partially-masked coarse cell. Their exact solution is rest, so
+# they need no gold file: plt00010 must equal plt00000. A plain arithmetic average-down
+# lets the zeroed fine land cells drag those coarse cells off their initial value, which
+# breaks stationarity by ~1e-2 in salt and velocity.
+add_test_0(DogboneAnalytic_MLmask       "remora_exec" "plt00010")
+add_test_0(DogboneAnalytic_MLmask_rr2   "remora_exec" "plt00010")
 add_test_r_differ(Seamount_hires         "remora_exec" "plt00010"    Seamount)
 add_test_r_differ(Seamount_hires_r4      "remora_exec" "plt00010"    Seamount_hires)
 

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -44,8 +44,8 @@ macro(setup_test)
     endif()
 
     # Set some default runtime options for all tests in this category
-    # set(RUNTIME_OPTIONS "time.max_step=10 amr.plot_file=plt time.plot_interval=10 amrex.throw_exception=1 amrex.signal_handling=0")
-    # set(RUNTIME_OPTIONS "max_step=10 amr.plot_file=plt amr.checkpoint_files_output=0 amr.plot_files_output=1 amrex.signal_handling=0")
+    # Validate the land/sea masks everywhere in the suite; it is off by default at run time.
+    set(RUNTIME_OPTIONS "remora.check_mask_consistency=true")
 
 endmacro(setup_test)
 
@@ -103,7 +103,7 @@ function(add_test_r_gold TEST_NAME TEST_EXE PLTFILE GOLD_NAME)
 
     set(FCOMPARE_TOLERANCE "-r 1e-11 --abs_tol 1.0e-11")
     set(FCOMPARE_FLAGS "-a ${FCOMPARE_TOLERANCE}")
-    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i > ${TEST_NAME}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${FCOMPARE_GOLD_FILES_DIRECTORY}/${GOLD_NAME} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
+    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${FCOMPARE_GOLD_FILES_DIRECTORY}/${GOLD_NAME} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
 
     add_test(${TEST_NAME} ${test_command})
     set_tests_properties(${TEST_NAME}
@@ -129,7 +129,7 @@ function(add_test_r_differ TEST_NAME TEST_EXE PLTFILE OTHER_GOLD)
 
     set(FCOMPARE_TOLERANCE "-r 1e-11 --abs_tol 1.0e-11")
     set(FCOMPARE_FLAGS "-a ${FCOMPARE_TOLERANCE}")
-    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i > ${TEST_NAME}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${PLOT_GOLD} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE} && ! ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${FCOMPARE_GOLD_FILES_DIRECTORY}/${OTHER_GOLD} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
+    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${PLOT_GOLD} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE} && ! ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${FCOMPARE_GOLD_FILES_DIRECTORY}/${OTHER_GOLD} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
 
     add_test(${TEST_NAME} ${test_command})
     set_tests_properties(${TEST_NAME}
@@ -165,7 +165,7 @@ function(add_test_equiv TEST_NAME OTHER_INPUT TEST_EXE PLTFILE OTHER_PLTFILE)
         string(REPLACE ";" " " EXTREMA_ARGS "${ARGN}")
         set(EXTREMA_CLAUSE " && ${CMAKE_CURRENT_SOURCE_DIR}/check_extrema.sh ${FEXTREMA_EXE} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE} ${EXTREMA_ARGS}")
     endif()
-    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i > ${TEST_NAME}.log 2>&1 && ${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${OTHER_INPUT}.i > ${OTHER_INPUT}.log 2>&1 && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${CURRENT_TEST_BINARY_DIR}/${OTHER_PLTFILE} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}${EXTREMA_CLAUSE}")
+    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log 2>&1 && ${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${OTHER_INPUT}.i ${RUNTIME_OPTIONS} > ${OTHER_INPUT}.log 2>&1 && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${CURRENT_TEST_BINARY_DIR}/${OTHER_PLTFILE} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}${EXTREMA_CLAUSE}")
 
     add_test(${TEST_NAME} ${test_command})
     set_tests_properties(${TEST_NAME}
@@ -190,7 +190,7 @@ function(add_test_abort TEST_NAME TEST_EXE ABORT_SUBSTRING)
 
     resolve_test_exe("${TEST_DIR}" "${TEST_EXE}" TEST_EXE)
 
-    set(test_command sh -c "! ${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i > ${TEST_NAME}.log 2>&1 && grep -q -- \"${ABORT_SUBSTRING}\" ${TEST_NAME}.log")
+    set(test_command sh -c "! ${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log 2>&1 && grep -q -- \"${ABORT_SUBSTRING}\" ${TEST_NAME}.log")
 
     add_test(${TEST_NAME} ${test_command})
     set_tests_properties(${TEST_NAME}
@@ -215,7 +215,7 @@ function(add_test_extrema TEST_NAME TEST_EXE PLTFILE TOL)
     resolve_test_exe("${TEST_DIR}" "${TEST_EXE}" TEST_EXE)
 
     string(REPLACE ";" " " EXTREMA_ARGS "${ARGN}")
-    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i > ${TEST_NAME}.log && ${CMAKE_CURRENT_SOURCE_DIR}/check_extrema.sh ${FEXTREMA_EXE} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE} ${TOL} ${EXTREMA_ARGS}")
+    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log && ${CMAKE_CURRENT_SOURCE_DIR}/check_extrema.sh ${FEXTREMA_EXE} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE} ${TOL} ${EXTREMA_ARGS}")
 
     add_test(${TEST_NAME} ${test_command})
     set_tests_properties(${TEST_NAME}

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -305,7 +305,7 @@ add_test_r(DogboneAnalytic_MLquad       "remora_exec" "plt_ml_quad00010")
 add_test_r_gold(Channel_Test_hires       "remora_exec" "plt00010"    Channel_Test)
 add_test_r_gold(DogboneAnalytic_MLhires  "remora_exec" "plt_ml00010" DogboneAnalytic_MLvel)
 
-# The only lanes with a partially-masked coarse cell. Their exact solution is rest, so
+# The only tests with a partially-masked coarse cell. Their exact solution is rest, so
 # they need no gold file: plt00010 must equal plt00000. A plain arithmetic average-down
 # lets the zeroed fine land cells drag those coarse cells off their initial value, which
 # breaks stationarity by ~1e-2 in salt and velocity.

--- a/Tests/test_files/DogboneAnalytic_MLmask/DogboneAnalytic_MLmask.i
+++ b/Tests/test_files/DogboneAnalytic_MLmask/DogboneAnalytic_MLmask.i
@@ -3,9 +3,10 @@
 #
 # Two things have to line up for one to exist. hires_grid_level resolves the coastline on the
 # refined level instead of injecting it from level 0; and a static box puts refined grids over
-# the coast, which velocity-tagged refinement never does, since masked cells and the land-sea
-# boundary are untagged. Offsetting mask_y_lo/mask_y_hi by one fine cell off a coarse face then
-# leaves coarse rows 5 and 9 covered by blocks that are 6 water cells out of 9.
+# the coast. The box is static because this case is at rest, so a field-based indicator like
+# DogboneAnalytic_MLvel's x_velocity > 0.05 would tag nothing anywhere. Offsetting
+# mask_y_lo/mask_y_hi by one fine cell off a coarse face then leaves coarse rows 5 and 9
+# covered by blocks that are 6 water cells out of 9.
 #
 # The exact solution is rest: flat bathymetry and free surface, uniform temperature and
 # salinity, no initial velocity, no Coriolis. So plt00010 must equal plt00000, with no gold

--- a/Tests/test_files/DogboneAnalytic_MLmask/DogboneAnalytic_MLmask.i
+++ b/Tests/test_files/DogboneAnalytic_MLmask/DogboneAnalytic_MLmask.i
@@ -1,0 +1,115 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+# Exercises a partially-masked coarse cell, which nothing else in the suite does.
+#
+# Two things have to line up for one to exist. hires_grid_level resolves the coastline on the
+# refined level instead of injecting it from level 0; and a static box puts refined grids over
+# the coast, which velocity-tagged refinement never does, since masked cells and the land-sea
+# boundary are untagged. Offsetting mask_y_lo/mask_y_hi by one fine cell off a coarse face then
+# leaves coarse rows 5 and 9 covered by blocks that are 6 water cells out of 9.
+#
+# The exact solution is rest: flat bathymetry and free surface, uniform temperature and
+# salinity, no initial velocity, no Coriolis. So plt00010 must equal plt00000, with no gold
+# file to bless. Under the ROMS wet-only mean the partially-masked coarse cells keep
+# exactly T = 10 and S = 35. Under a plain arithmetic mean the land cells, which
+# advance_3d_ml zeroes every step, drag them to 6/9 of that and the run stops being
+# stationary, so a lost mask weighting fails loudly.
+remora.prob_name = DogboneAnalytic
+
+remora.max_step = 10
+
+amrex.fpe_trap_invalid=1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =   0.       0.  -10.
+remora.prob_hi     =   8400.  750.       0.
+
+remora.n_cell           =  42 15 16
+
+amr.blocking_factor_z = 16
+
+amr.max_grid_size_z = 1024
+
+remora.is_periodic = 0 0 0
+
+remora.bc.xlo.type = "slipwall"
+remora.bc.xhi.type = "slipwall"
+remora.bc.ylo.type = "slipwall"
+remora.bc.yhi.type = "slipwall"
+
+# TIME STEP CONTROL
+remora.fixed_dt            = 2.0 # Timestep size (seconds)
+remora.ndtfast = 20
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 1       # maximum level number allowed
+amr.ref_ratio_vect = 3 3  1
+amr.regrid_int      = -1      # static: the grids must not move between the two plotfiles
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1
+remora.v             = 0
+
+# CHECKPOINT FILES
+remora.check_file      = chk
+
+# PLOTFILES
+remora.plot_file     = plt
+remora.plot_int      = 10
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plot_vars_2d  = mask_rho   # a rho2d sidecar, for eyeballing a failure; fcompare ignores it
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.tracer_horizontal_advection_scheme = "upstream3"
+
+remora.Akt_bak = 1e-6
+remora.Akv_bak = 1e-5
+
+remora.use_coriolis  = false
+
+remora.theta_s = 0.0
+remora.theta_b = 0.0
+remora.tcline = 1e16
+
+remora.bottom_stress_type = "quadratic"
+remora.rdrag2 = 3.0e-3
+
+remora.mask_type = "analytic"
+
+remora.init_l1ad_h =false
+remora.init_l1ad_T =false
+
+remora.init_l0int_h =true
+remora.init_l0int_T =true
+
+remora.init_ana_h = false
+remora.init_ana_T = false
+
+# PROBLEM PARAMETERS
+remora.R0    = 1027.0
+remora.S0    = 35.0
+remora.T0    = 10.0
+remora.Tcoef = 1.7e-4
+remora.Scoef = 7.6e-4
+remora.rho0  = 1025.0
+
+remora.ic_type       = "analytic"
+
+# Rest as the exact solution
+remora.prob.zeta_bump = false
+remora.prob.temp_west = 10.0
+
+# Coast offset by one fine cell (dy_1 = 50/3) off the coarse cell face
+remora.prob.mask_y_lo = 266.66666666666667
+remora.prob.mask_y_hi = 483.33333333333333
+
+# Static refinement over the coast
+remora.refinement_indicators = coastbox
+remora.coastbox.max_level = 1
+remora.coastbox.in_box_lo = 2600. 0.
+remora.coastbox.in_box_hi = 5800. 750.
+
+remora.coupling_type = "TwoWay"
+
+# Mask specified on the refined level and coarsened down to level 0
+remora.hires_grid_level = 1

--- a/Tests/test_files/DogboneAnalytic_MLmask_rr2/DogboneAnalytic_MLmask_rr2.i
+++ b/Tests/test_files/DogboneAnalytic_MLmask_rr2/DogboneAnalytic_MLmask_rr2.i
@@ -1,0 +1,116 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+# DogboneAnalytic_MLmask at an even refinement ratio, where the partially-masked blocks
+# are half water rather than two thirds.
+#
+# Two things have to line up for one to exist. hires_grid_level resolves the coastline on the
+# refined level instead of injecting it from level 0; and a static box puts refined grids over
+# the coast, which velocity-tagged refinement never does, since masked cells and the land-sea
+# boundary are untagged. Offsetting mask_y_lo/mask_y_hi by one fine cell off a coarse face then
+# leaves coarse rows 5 and 9 covered by blocks that are 2 water cells out of 4.
+#
+# The exact solution is rest: flat bathymetry and free surface, uniform temperature and
+# salinity, no initial velocity, no Coriolis. So plt00010 must equal plt00000, with no gold
+# file to bless. Under the ROMS wet-only mean the partially-masked coarse cells keep
+# exactly T = 10 and S = 35. Under a plain arithmetic mean the land cells, which
+# advance_3d_ml zeroes every step, drag them to half of that and the run stops being
+# stationary, so a lost mask weighting fails loudly.
+remora.prob_name = DogboneAnalytic
+
+remora.max_step = 10
+
+amrex.fpe_trap_invalid=1
+
+# PROBLEM SIZE & GEOMETRY
+remora.prob_lo     =   0.       0.  -10.
+remora.prob_hi     =   8400.  750.       0.
+
+remora.n_cell           =  42 15 16
+
+amr.blocking_factor_z = 16
+
+amr.max_grid_size_z = 1024
+
+remora.is_periodic = 0 0 0
+
+remora.bc.xlo.type = "slipwall"
+remora.bc.xhi.type = "slipwall"
+remora.bc.ylo.type = "slipwall"
+remora.bc.yhi.type = "slipwall"
+
+# TIME STEP CONTROL
+remora.fixed_dt            = 2.0 # Timestep size (seconds)
+remora.ndtfast = 20
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 1       # maximum level number allowed
+amr.ref_ratio_vect = 2 2  1
+amr.regrid_int      = -1      # static: the grids must not move between the two plotfiles
+
+# DIAGNOSTICS & VERBOSITY
+remora.sum_interval  = 1
+remora.v             = 0
+
+# CHECKPOINT FILES
+remora.check_file      = chk
+
+# PLOTFILES
+remora.plot_file     = plt
+remora.plot_int      = 10
+remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
+remora.plot_vars_2d  = mask_rho   # a rho2d sidecar, for eyeballing a failure; fcompare ignores it
+remora.plotfile_type = amrex
+
+# SOLVER CHOICE
+remora.tracer_horizontal_advection_scheme = "upstream3"
+
+remora.Akt_bak = 1e-6
+remora.Akv_bak = 1e-5
+
+remora.use_coriolis  = false
+
+remora.theta_s = 0.0
+remora.theta_b = 0.0
+remora.tcline = 1e16
+
+remora.bottom_stress_type = "quadratic"
+remora.rdrag2 = 3.0e-3
+
+remora.mask_type = "analytic"
+
+remora.init_l1ad_h =false
+remora.init_l1ad_T =false
+
+remora.init_l0int_h =true
+remora.init_l0int_T =true
+
+remora.init_ana_h = false
+remora.init_ana_T = false
+
+# PROBLEM PARAMETERS
+remora.R0    = 1027.0
+remora.S0    = 35.0
+remora.T0    = 10.0
+remora.Tcoef = 1.7e-4
+remora.Scoef = 7.6e-4
+remora.rho0  = 1025.0
+
+remora.ic_type       = "analytic"
+
+# Rest as the exact solution
+remora.prob.zeta_bump = false
+remora.prob.temp_west = 10.0
+
+# Coast offset by one fine cell (dy_1 = 25) off the coarse cell face
+remora.prob.mask_y_lo = 275.0
+remora.prob.mask_y_hi = 475.0
+
+# Static refinement over the coast
+remora.refinement_indicators = coastbox
+remora.coastbox.max_level = 1
+remora.coastbox.in_box_lo = 2600. 0.
+remora.coastbox.in_box_hi = 5800. 750.
+
+remora.coupling_type = "TwoWay"
+
+# Mask specified on the refined level and coarsened down to level 0
+remora.hires_grid_level = 1

--- a/Tests/test_files/DogboneAnalytic_MLmask_rr2/DogboneAnalytic_MLmask_rr2.i
+++ b/Tests/test_files/DogboneAnalytic_MLmask_rr2/DogboneAnalytic_MLmask_rr2.i
@@ -4,9 +4,10 @@
 #
 # Two things have to line up for one to exist. hires_grid_level resolves the coastline on the
 # refined level instead of injecting it from level 0; and a static box puts refined grids over
-# the coast, which velocity-tagged refinement never does, since masked cells and the land-sea
-# boundary are untagged. Offsetting mask_y_lo/mask_y_hi by one fine cell off a coarse face then
-# leaves coarse rows 5 and 9 covered by blocks that are 2 water cells out of 4.
+# the coast. The box is static because this case is at rest, so a field-based indicator like
+# DogboneAnalytic_MLvel's x_velocity > 0.05 would tag nothing anywhere. Offsetting
+# mask_y_lo/mask_y_hi by one fine cell off a coarse face then leaves coarse rows 5 and 9
+# covered by blocks that are 2 water cells out of 4.
 #
 # The exact solution is rest: flat bathymetry and free surface, uniform temperature and
 # salinity, no initial velocity, no Coriolis. So plt00010 must equal plt00000, with no gold

--- a/Tests/tools/make_hires_test_data.py
+++ b/Tests/tools/make_hires_test_data.py
@@ -6,12 +6,19 @@ Writes two files in **64-bit offset classic** (CDF-2) format, matching the ``*_c
 convention used throughout REMORA's inputs. PnetCDF cannot read NETCDF4/HDF5, so the format is
 not negotiable -- the writer below pins it explicitly and refuses to guess.
 
-    <dir>/hires_grd.nc   h, pm, pn                    (SN_WE)
+    <dir>/hires_grd.nc   h, pm, pn, mask_rho          (SN_WE)
     <dir>/hires_ini.nc   temp, salt, u, v, zeta       (Time_BT_SN_WE / Time_SN_WE)
 
-Only the variables the hires readers actually consume are written. With both hires levels set,
-plus ``remora.use_coriolis = false`` and ``remora.mask_type = none``, the level-0 files are never
-dereferenced, so no ``x_rho``, ``f`` or ``mask_*`` are needed anywhere.
+Only the variables the hires readers actually consume are written. With both hires levels set
+and ``remora.use_coriolis = false``, the level-0 files are never dereferenced, so no ``x_rho``
+or ``f`` is needed anywhere. ``mask_rho`` is written so that ``remora.mask_type = netcdf`` also
+works off the hires file alone; ``mask_u``/``mask_v`` are not, since the hires reader derives
+them from ``mask_rho`` the way ROMS defines them.
+
+The coastline is placed one *fine* row above a coarse cell face, which is the whole point: it
+leaves the coarse row straddling it partly wet, so the mask-weighted coarsening of the
+bathymetry and of the initial state has something to do. A coastline on a coarse face would
+make every block wholly wet or wholly dry and the weighting would be untestable.
 
 The grow-cell rule (Docs/sphinx_doc/Inputs.rst) fixes the dimensions::
 
@@ -131,10 +138,20 @@ def main():
     pm = (1.0 / dx_f) * (1.0 + 0.06 * np.sin(2.0 * np.pi * X / lx))
     pn = (1.0 / dx_f) * (1.0 - 0.06 * np.cos(2.0 * np.pi * Y / ly))
 
+    # Land along the southern edge, with the coastline one fine row above the coarse cell face
+    # at y = 2*dx, so coarse row 2 comes out (r-1)/r water and the mask weighting is exercised.
+    # Deliberately the simplest geometry that does that: a wavier coast risks a coarse face that
+    # is open with no open fine face beneath it, which check_mask_consistency rejects.
+    ycut = 2.0 * args.dx + dx_f
+    mask_rho = np.where(Y < ycut, 0.0, 1.0)
+
     grd = os.path.join(args.dir, "hires_grd.nc")
     fh, kind = open_cdf2(grd, {"eta_rho": eta_rho, "xi_rho": xi_rho})
     put(fh, kind, "h", ("eta_rho", "xi_rho"), h, units="meter",
         long_name="bathymetry at RHO-points")
+    put(fh, kind, "mask_rho", ("eta_rho", "xi_rho"), mask_rho,
+        long_name="mask on RHO-points", flag_values="0., 1.",
+        flag_meanings="land water")
     put(fh, kind, "pm", ("eta_rho", "xi_rho"), pm, units="meter-1",
         long_name="curvilinear coordinate metric in XI")
     put(fh, kind, "pn", ("eta_rho", "xi_rho"), pn, units="meter-1",


### PR DESCRIPTION
## The problem

A refined level could not carry its own coastline. Every level above 0 got a piecewise-constant
injection of the level-0 mask, so refining never improved the coast — even under
`hires_grid_level`, where the bathymetry *did* come from the fine grid. A run could have
high-resolution depths beneath a coarse-resolution coast, and needed a level-0 grid file purely
to supply that coarse mask.

Two-way coupling then averaged the fine level down with a plain arithmetic mean. Fine land cells
hold zero, since `advance_3d_ml` zeroes them every step, so a coarse cell only partly covered by
water had its tracers pulled toward zero in proportion to the land beneath it. The same applied
to the high-resolution bathymetry and initial state.

## What changed

**The mask is specified once and every other level derived from it**, mirroring how bathymetry
already works: on level 0, or at `hires_grid_level` over the whole domain. Levels at or below it
take the mask coarsened down, levels above are injected piecewise-constant. No level reads its
own independent mask, so the levels cannot disagree about where the coast is.

Coarsening takes **a coarse cell as land only if all of its fine cells are land**. An arithmetic
mean would give fractional values, and the mask must stay exactly 0 or 1 — the plotfile writer
compares it against 0 with `==`.

### Behavior change for analytic masks

Injecting above the specification level is what the NetCDF path already did, but **not** what
`mask_type = analytic` did: its branch of the old `set_masks` had no `lev` test, so
`init_analytic_masks` was evaluated at every level, each at its own resolution. A prob whose
analytic coastline resolves finer than level 0 therefore loses that detail on refined levels —
silently, since the coast is still a valid mask.

That is the price of one specification, and it is recoverable: set `hires_grid_level` and the
hook is evaluated at that level over the whole domain, which is strictly better than what the old
per-level evaluation gave, because the coarse levels then agree with it. In-tree gold files do not
move only because the Dogbone coast sits on coarse cell faces at both tested ratios, so every
block is wholly wet or wholly dry either way.

**The fine-to-coarse average is mask-weighted**, following ROMS `fine2coarse2d`/`fine2coarse3d`
(`Nonlinear/nesting.F`, the `AreaAvg = .FALSE.` branch every call site there uses):

```
num  = sum of (fine value * fine mask)
den  = sum of min(1, fine mask)
crse = num/den * coarse mask
```

Dividing by the count of *wet* fine points rather than by how many there are means a partly
covered coarse cell takes the mean of the water under it. Not conservative; ROMS makes the same
trade deliberately.

That citation covers the state fields only — free surface, tracers and momenta, which is what
ROMS applies `fine2coarse` to, and with the same mask for each (`rmask` for the free surface and
tracers, `umask`/`vmask` for the momenta). **The high-resolution bathymetry and initial state
extend the formula by analogy, with no ROMS precedent.** ROMS has no runtime bathymetry
coarsening at all — each nested grid reads its own `h` — and where its offline tooling builds a
coarse grid from a fine one (`Tools/mfiles/rutgers/grid/fine2coarse.m`) it *decimates*: it
strides `Gfactor` points through the fine grid and copies `h` and the four masks, averaging only
`dx`/`dy`, which have to match the new spacing. So both the mask-coarsening rule above and the
weighted `h` are this branch's own choices. Decimation is defensible for generating a grid file
and poor for a runtime cascade, which has to keep the levels agreeing about how much water there
is; but it is worth being clear that ROMS is not the authority for those two.

The two also differ in what they do when a coarse cell has no wet fine cell under it. `h` falls
back to the plain mean, since a depth under land still has to hold something; the initial state
takes the formula as written above and is left at zero by the coarse-mask multiply.

Where every fine point is wet the kernels reproduce `amrex_avgdown` and `amrex_avgdown_faces`
**bit for bit**, which is what leaves every existing multilevel answer unchanged. That needs
AMReX's iteration order, the mask multiplying the value before it is accumulated, and the
division written as a multiplication by the reciprocal.

## New inputs

| | | default |
|---|---|---|
| `remora.check_mask_consistency` | debug option: validate the masks at startup and each regrid | `false` |
| `remora.mask_consistency` | `abort` or `warn` on failure; read only when the check is on | `abort` |

The check validates that the masks hold only 0 and 1 (psi also 2), that no water cell has a
non-positive depth, and that no coarse water point sits over fine points that are all land, which
would leave the weighted average nothing to divide by. Off by default because it checks the
machinery rather than user input; the regression suite runs with it on.

## Testing

`DogboneAnalytic_MLmask` and `_MLmask_rr2` are the only tests with a partially masked coarse cell.
Producing one needs both `hires_grid_level`, so the coast is resolved on the refined level, and a
static box placing the fine grids over the coast — these cases are at rest, so a field-based
indicator would tag nothing anywhere.

Their exact solution is rest, so they need no reference file: `plt00010` must equal `plt00000` to
1e-14. Under a plain mean the zeroed fine land cells drag those coarse cells off their initial
value and stationarity breaks by ~1e-2, so a lost weighting fails loudly rather than matching its
own snapshot. Checked in both directions before landing.

All 33 tests pass, bit-identically, in both a NetCDF and a non-NetCDF build.

## Also fixed

- `set_masks` now runs before the `FillPatch` calls in `MakeNewLevelFromCoarse` and
  `RemakeLevel`, which previously filled every state variable against an all-water placeholder.
  Measured to change no answer, so this is legibility.
- The psi mask had two definitions — ROMS's 0/1/2 free-slip rule or a plain product — depending on
  how a level was built. Now uniform.
- The nodal masks had one of three ghost rings written, and `vec_mskr3d` was stale on regridded
  levels, silently disabling the mask derefinement criteria at `max_level >= 2`.
- `REMORA(rb, ...)` never populated `cum_ref_ratios`, so every index into it read out of bounds.
  Latent, since nothing in the tree uses that constructor. Fixed by sharing the loop rather than
  duplicating it.
- Only the rho-point mask is now read or given analytically; the u-, v- and psi-point masks are
  derived from it everywhere, as ROMS `set_masks.F` defines them. A grid file's `mask_u` and
  `mask_v` used to be read at level 0 while every other path derived them, so there were two
  sources of truth and a check existed only to assert they agreed. Verified against a ROMS grid
  file carrying all four: the derived masks reproduce the file's exactly.
- `hires_grd.nc` gains `mask_rho`, and the Dogbone analytic mask and bathymetry hooks derive
  coordinates from the `Geometry`, so they work on the full-domain MultiFab.

## Not covered

- No test makes `check_mask_consistency` fail. With one specification coarsened downward an
  inconsistency cannot be produced from inputs alone, so it was verified by hand.
- The high-resolution bathymetry and initial-state weighting have no CI test: the checked-in
  `hires_grd.nc` needs the regenerated version (a separate `REMORA-data` commit), and the
  `MLmask` tests need flat `h` for their stationarity argument. Both verified by hand — disabling
  the weighting moves velocities 2.3% and 0.4–1.3% respectively within two steps.
- ROMS's `mask_hweights` has no analogue here and needs none. A wet fine cell's covering coarse
  cell is always wet by construction, and AMReX's interpolators limit their slopes, so a land
  neighbour collapses the slope to zero rather than being blended in. ROMS needs the
  renormalization because its contact-point weights are unlimited.
- `fine2coarse2d`'s `WET_DRY` clamp is not ported. Immediately after the coarse-mask multiply
  ROMS holds the coarse free surface above the critical depth:
  `IF (my_avg.le.(Dcrit(ng)-hhC(Ic,Jc))) my_avg=Dcrit(ng)-hhC(Ic,Jc)`, for `r2dvar` only. REMORA
  has no wet/dry scheme and no `Dcrit`, so there is nothing to clamp against.
