### PR TITLE
Record the simulation start time as `dstart`, not an uninitialized `start_time`

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -522,10 +522,16 @@ the run within the calendar the way ROMS ``DSTART`` does. With the default
 ``time_ref = 0``, a run starting on 1 January 2020 sets
 ``remora.start_time = 63713433600``.
 
-Only features that need a date consult this: at present the time-dependent
-atmospheric CO2 options of the Fennel biology model, see :ref:`sec:Fennel`. The
-conversion is ``remora_caldate`` in ``Source/Utils/REMORA_DateClock.H``, a port
-of ROMS ``caldate``.
+NetCDF output records that offset as the scalar variable ``dstart``, in days
+since the reference date, as ROMS does. ``dstart`` and ``ocean_time`` both carry
+the reference date in their ``units`` attribute and the calendar in a
+``calendar`` attribute, so an output file can be read as dates without knowing
+``remora.time_ref``.
+
+Otherwise only features that need a date consult this: at present the
+time-dependent atmospheric CO2 options of the Fennel biology model, see
+:ref:`sec:Fennel`. The conversion is ``remora_caldate`` in
+``Source/Utils/REMORA_DateClock.H``, a port of ROMS ``caldate``.
 
 .. _notes-3:
 

--- a/Docs/sphinx_doc/testing.rst
+++ b/Docs/sphinx_doc/testing.rst
@@ -137,21 +137,17 @@ condition with no time stepper in the way.
 Unit tests
 ~~~~~~~~~~
 
-Everything above drives the full executable. A header of pure functions is better checked directly, and
-those tests live in ``Tests/Unit``, built as ``remora_unit_tests`` and labelled ``unit``, so
-``ctest -L unit`` runs them alone in under a second and ``ctest -LE unit`` skips them.
+Unit tests that exercise individual functions live in ``Tests/Unit``, built as ``remora_unit_tests`` and
+labelled ``unit`` so ``ctest -L unit`` runs them alone and ``ctest -LE unit`` skips them.
 
 There is no framework: a unit test is a ``main()`` that checks answers, prints a line per failure, and
-returns nonzero -- the contract ``ctest`` already uses for every other lane. To add one, drop a ``.cpp``
+returns nonzero. To add one, add a ``.cpp``
 beside the existing test and list it in ``Tests/Unit/CMakeLists.txt``. The target links AMReX, so a test
 sees the same precision as the build around it; a case that only holds in double has to be gated on that
 rather than assumed.
 
-Take expected values from *outside* the implementation, or the test only records what the code did the day
-it was written -- a gold file's weakness. ``REMORA_DateClock_test.cpp`` is the worked example: Matlab
-``datenum`` values, the anchors ROMS ``dateclock.F`` states in its own comments, Gregorian arithmetic for
-days of the year. Better still, assert a property: that ``datevec`` inverts ``datenum`` needs no outside
-authority and covers far more inputs than a table.
+The unit test ``REMORA_DateClock_test.cpp`` tests that the date and calendar functions in
+``REMORA_DateClock.H`` match ROMS's ``dateclock.F``.
 
 Regenerating gold files
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/Docs/sphinx_doc/testing.rst
+++ b/Docs/sphinx_doc/testing.rst
@@ -36,7 +36,7 @@ While performing a ``cmake -LAH ..`` command will give descriptions of every opt
 
 **REMORA_ENABLE_FCOMPARE** -- builds the ``fcompare`` utility from AMReX as well as the executable(s), to allow for testing differences between plot files
 
-**REMORA_ENABLE_TESTS** -- enables the base level regression test suite that will check whether each test will run its executable to completion successfully
+**REMORA_ENABLE_TESTS** -- enables the base level regression test suite that will check whether each test will run its executable to completion successfully, and the unit tests in ``Tests/Unit``
 
 
 Building the Tests
@@ -133,6 +133,25 @@ say the baseline was right, and it cannot notice a feature that has silently sto
 Cheap lanes are worth adding: ``remora.max_step = 0`` with ``remora.plot_int = 1`` is a legal
 initialize-and-dump run of about a second, which is enough for ``add_test_extrema`` to pin an initial
 condition with no time stepper in the way.
+
+Unit tests
+~~~~~~~~~~
+
+Everything above drives the full executable. A header of pure functions is better checked directly, and
+those tests live in ``Tests/Unit``, built as ``remora_unit_tests`` and labelled ``unit``, so
+``ctest -L unit`` runs them alone in under a second and ``ctest -LE unit`` skips them.
+
+There is no framework: a unit test is a ``main()`` that checks answers, prints a line per failure, and
+returns nonzero -- the contract ``ctest`` already uses for every other lane. To add one, drop a ``.cpp``
+beside the existing test and list it in ``Tests/Unit/CMakeLists.txt``. The target links AMReX, so a test
+sees the same precision as the build around it; a case that only holds in double has to be gated on that
+rather than assumed.
+
+Take expected values from *outside* the implementation, or the test only records what the code did the day
+it was written -- a gold file's weakness. ``REMORA_DateClock_test.cpp`` is the worked example: Matlab
+``datenum`` values, the anchors ROMS ``dateclock.F`` states in its own comments, Gregorian arithmetic for
+days of the year. Better still, assert a property: that ``datevec`` inverts ``datenum`` needs no outside
+authority and covers far more inputs than a table.
 
 Regenerating gold files
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/Source/BoundaryConditions/REMORA_FillPatch.cpp
+++ b/Source/BoundaryConditions/REMORA_FillPatch.cpp
@@ -516,35 +516,6 @@ REMORA::FillCoarsePatchMap (int lev, Real time, MultiFab* mf_to_fill, MultiFab* 
         }
     }
 
-#if 0
-    TimeInterpolatedData cdata = GetDataAtTime(lev-1, time);
-    TimeInterpolatedData fdata = GetDataAtTime(lev  , time);
-    Vector<Real> ctime = {cdata.get_time()};
-
-    Vector<MultiFab*> cmf = {mf_crse};
-    Vector<Real> ctime = {time};
-
-    REMORAPhysBCFunct cphysbc(lev-1,geom[lev-1],
-                             domain_bcs_type,domain_bcs_type_d,
-                             cdata,
-                             m_bc_extdir_vals
-#ifdef REMORA_USE_NETCDF
-                            ,ic_type,bdy_data_xlo,bdy_data_xhi,
-                             bdy_data_ylo,bdy_data_yhi,bdy_time_interval
-#endif
-                            );
-    REMORAPhysBCFunct fphysbc(lev,geom[lev],
-                             domain_bcs_type,domain_bcs_type_d,
-                             fdata,
-                             m_bc_extdir_vals
-#ifdef REMORA_USE_NETCDF
-                            ,ic_type,bdy_data_xlo,bdy_data_xhi,
-                             bdy_data_ylo,bdy_data_yhi,bdy_time_interval
-#endif
-                            );
-#endif
-
-
     mf_crse->FillBoundary(geom[lev-1].periodicity());
     amrex::InterpFromCoarseLevel(*mf_to_fill, mf_to_fill->nGrowVect(), IntVect(0,0,0),
             *mf_crse, 0, icomp, ncomp, geom[lev-1], geom[lev],

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -14,6 +14,7 @@
 #include <AMReX_ParmParse.H>
 
 #include "REMORA.H"
+#include "REMORA_DateClock.H"
 #include "REMORA_NCInterface.H"
 #include "REMORA_NCPlotFile.H"
 #include "REMORA_IndexDefines.H"
@@ -438,10 +439,24 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
         ncf.var("y_psi").put_attr("units","meter");
         ncf.var("y_psi").put_attr("field","y_psi, scalar");
 
+        // Both time stamps run on the model clock, so both carry the reference
+        // date remora.time_ref names, as ROMS writes Rclock%string.
+        const std::string ref_date_string = remora_ref_date_string(solverChoice.time_ref);
+        const std::string ref_calendar = remora_ref_calendar(solverChoice.time_ref);
+
         ncf.def_var("ocean_time", ncutils::NCDType::Real, { nt_name });
         ncf.var("ocean_time").put_attr("long_name","time since initialization");
-        ncf.var("ocean_time").put_attr("units","seconds since 0001-01-01 00:00:00");
+        ncf.var("ocean_time").put_attr("units","seconds since " + ref_date_string);
+        ncf.var("ocean_time").put_attr("calendar",ref_calendar);
         ncf.var("ocean_time").put_attr("field","time, scalar, series");
+
+        // ROMS DSTART: when the run starts, in days on the model clock. Double
+        // regardless of Real -- days since year 1 needs more than a float's
+        // seven significant digits, which would round this to the nearest hour.
+        ncf.def_var("dstart", NC_DOUBLE, {});
+        ncf.var("dstart").put_attr("long_name","time stamp assigned to model initialization");
+        ncf.var("dstart").put_attr("units","days since " + ref_date_string);
+        ncf.var("dstart").put_attr("calendar",ref_calendar);
 
         ncf.def_var("Cs_r", ncutils::NCDType::Real, {nz_r_name});
         ncf.var("Cs_r").put_attr("long_name", "S-coordinate stretching curves at RHO points");
@@ -733,7 +748,6 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
         // Right now this is hard-wired to {temp, salt, tracer, u, v}
         ncf.put_attr("space_dimension", std::vector<int> { AMREX_SPACEDIM });
 //        ncf.put_attr("current_time", std::vector<double> { time });
-        ncf.put_attr("start_time", std::vector<double> { start_bdy_time });
         ncf.put_attr("CurrentLevel", std::vector<int> { flev });
         ncf.put_attr("DefaultGeometry", std::vector<int> { amrex::DefaultGeometry().Coord() });
 
@@ -808,6 +822,10 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             ncf.var("hc").put(&hc);
             ncf.var("theta_s").put(&theta_s);
             ncf.var("theta_b").put(&theta_b);
+
+            // remora.start_time in seconds is ROMS DSTART in days.
+            double dstart = static_cast<double>(start_time) / 86400.0;
+            ncf.var("dstart").put(&dstart);
 
         }
         ncmpi_end_indep_data(ncf.ncid);

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1422,11 +1422,6 @@ private:
                          int coordinatorProc = amrex::ParallelDescriptor::IOProcessorNumber(),
                          int allow_empty_mf = 0);
 
-    /** \brief Start time in the time series of boundary data */
-    amrex::Real start_bdy_time;
-    /** \brief Interval between boundary data times */
-    amrex::Real bdy_time_interval;
-
     /** \brief Whether to output NetCDF files as a single history file with several time steps */
     static bool write_history_file;
 

--- a/Source/Utils/REMORA_DateClock.H
+++ b/Source/Utils/REMORA_DateClock.H
@@ -3,6 +3,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <string>
 #include <type_traits>
 
 #include <AMReX_REAL.H>
@@ -36,10 +38,12 @@
  * -- and in the `time_ref = -2` conversion it does, which rounds differently
  * from `INT` on the negative side of the epoch -- `std::floor` is used here.
  *
- * Hours, minutes and seconds are not returned. ROMS derives them from the day
- * fraction through the tolerant rounding helper in `round_mod`, and
- * half-porting that would be worse than leaving it out; the day fraction is
- * available from remora_caldate's `yday` for a caller that needs it.
+ * remora_caldate does not return hours, minutes or seconds. ROMS derives them
+ * from the day fraction through the tolerant rounding helper in `round_mod`,
+ * and half-porting that would be worse than leaving it out; the day fraction is
+ * available from remora_caldate's `yday` for a caller that needs it. The
+ * reference date does carry a time of day -- `remora.time_ref` can name one --
+ * and remora_ref_clock returns it.
  *
  * Two quirks of the `time_ref = -2` calendar carry over, both ROMS's and both
  * confirmed against the Fortran rather than inferred:
@@ -140,9 +144,52 @@ amrex::Real remora_datenum (amrex::Real time_ref, int year, int month, int day,
 }
 
 /**
+ * \brief Reference date the model clock counts from, implied by \p time_ref.
+ *
+ * ROMS `ref_clock`'s date decode, the fields behind `Rclock%string`. The
+ * sentinel calendars carry ROMS's hardcoded dates: 0000-12-30 for 360_day,
+ * whose epoch is shifted back a day to undo a historical one-day offset,
+ * 1968-05-23 for the truncated Julian day, and 0001-01-01 for `time_ref = 0`.
+ */
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void remora_ref_clock (amrex::Real time_ref, int& year, int& month, int& day,
+                       int& hour, int& minute, int& second) noexcept
+{
+    const int cal = static_cast<int>(time_ref);
+
+    if (cal > 0) {
+        // Decode yyyymmdd.dd. The clamps are ROMS's, and they are what keeps a
+        // malformed value from indexing off the end of the calendar.
+        year = std::max(1, static_cast<int>(time_ref * amrex::Real(0.0001)));
+        month = std::min(12, std::max(1, static_cast<int>(
+            (time_ref - amrex::Real(year * 10000)) * amrex::Real(0.01))));
+        const amrex::Real fday = time_ref -
+            std::trunc(time_ref * amrex::Real(0.01)) * amrex::Real(100.0);
+        day = std::max(1, static_cast<int>(fday));
+        const amrex::Real sec = (fday - std::trunc(fday)) * amrex::Real(86400.0);
+        hour = static_cast<int>(sec / amrex::Real(3600.0));
+        minute = static_cast<int>(std::fmod(sec, amrex::Real(3600.0)) /
+                                  amrex::Real(60.0));
+        second = static_cast<int>(std::fmod(sec, amrex::Real(60.0)));
+
+    } else if (cal == -1) {
+        year = 0; month = 12; day = 30;       // 360_day, epoch shifted back a day
+        hour = 0; minute = 0; second = 0;
+
+    } else if (cal == -2) {
+        year = 1968; month = 5; day = 23;     // truncated Julian day
+        hour = 0; minute = 0; second = 0;
+
+    } else {
+        year = 1; month = 1; day = 1;         // proleptic Gregorian
+        hour = 0; minute = 0; second = 0;
+    }
+}
+
+/**
  * \brief Day number of the reference date implied by \p time_ref.
  *
- * ROMS `ref_clock`, reduced to the one field the rest of this header needs:
+ * ROMS `ref_clock`, reduced to the one field most of this header needs:
  * `Rclock%DateNumber(1)`. The two negative calendars carry hardcoded values in
  * ROMS -- 359 for 360_day, whose epoch is shifted to 0000-12-30 to undo a
  * historical one-day offset, and 2440000 for the truncated Julian day.
@@ -152,30 +199,19 @@ amrex::Real remora_ref_datenum (amrex::Real time_ref) noexcept
 {
     const int cal = static_cast<int>(time_ref);
 
-    if (cal > 0) {
-        // Decode yyyymmdd.dd. The clamps are ROMS's, and they are what keeps a
-        // malformed value from indexing off the end of the calendar.
-        const int iyear = std::max(1, static_cast<int>(time_ref * amrex::Real(0.0001)));
-        const int month = std::min(12, std::max(1, static_cast<int>(
-            (time_ref - amrex::Real(iyear * 10000)) * amrex::Real(0.01))));
-        const amrex::Real day = time_ref -
-            std::trunc(time_ref * amrex::Real(0.01)) * amrex::Real(100.0);
-        const int iday = std::max(1, static_cast<int>(day));
-        const amrex::Real sec = (day - std::trunc(day)) * amrex::Real(86400.0);
-        const int ihour = static_cast<int>(sec / amrex::Real(3600.0));
-        const int minute = static_cast<int>(std::fmod(sec, amrex::Real(3600.0)) /
-                                            amrex::Real(60.0));
-        const int isec = static_cast<int>(std::fmod(sec, amrex::Real(60.0)));
-        return remora_datenum(time_ref, iyear, month, iday, ihour, minute,
-                              amrex::Real(isec));
-    }
     if (cal == -1) {
         return amrex::Real(359.0);            // 0000-12-30 in the 360_day calendar
     }
     if (cal == -2) {
         return amrex::Real(2440000.0);        // 1968-05-23, truncated Julian offset
     }
-    return remora_datenum(time_ref, 1, 1, 1); // 0001-01-01, equals 367
+
+    // Gregorian and proleptic Gregorian, including time_ref = 0, whose
+    // 0001-01-01 comes back from remora_ref_clock and equals 367.
+    int year, month, day, hour, minute, second;
+    remora_ref_clock(time_ref, year, month, day, hour, minute, second);
+    return remora_datenum(time_ref, year, month, day, hour, minute,
+                          amrex::Real(second));
 }
 
 /**
@@ -368,6 +404,48 @@ bool remora_time_ref_is_representable (amrex::Real time_ref) noexcept
         return true;
     }
     return std::is_same<amrex::Real, double>::value;
+}
+
+/**
+ * \brief CF calendar name for \p time_ref. ROMS `ref_clock`'s `Rclock%calendar`.
+ *
+ * Written next to every time stamp in NetCDF output, so a reader can tell which
+ * calendar the model clock is on.
+ */
+AMREX_FORCE_INLINE
+std::string remora_ref_calendar (amrex::Real time_ref)
+{
+    const int cal = static_cast<int>(time_ref);
+
+    if (cal == -1) {
+        return "360_day";
+    }
+    if (cal == -2) {
+        return "gregorian";
+    }
+    return "proleptic_gregorian";
+}
+
+/**
+ * \brief Reference date as `YYYY-MM-DD hh:mm:ss`. ROMS `ref_clock`'s `Rclock%string`.
+ *
+ * The "since" half of a CF time-units attribute: prefix `days since` or
+ * `seconds since` to get the units of a time stamp on the model clock. Host
+ * only, since it builds a std::string.
+ */
+AMREX_FORCE_INLINE
+std::string remora_ref_date_string (amrex::Real time_ref)
+{
+    int year, month, day, hour, minute, second;
+    remora_ref_clock(time_ref, year, month, day, hour, minute, second);
+
+    // ROMS FORMAT (i4.4,'-',i2.2,'-',i2.2,1x,i2.2,':',i2.2,':',i2.2). Sized for
+    // the widest an int can print in all six fields, not the 19 characters a
+    // real date takes, so the compiler can see the format never truncates.
+    char buf[6 * 11 + 5 + 1];
+    std::snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d",
+                  year, month, day, hour, minute, second);
+    return std::string(buf);
 }
 
 #endif

--- a/Source/Utils/REMORA_DateClock.H
+++ b/Source/Utils/REMORA_DateClock.H
@@ -38,12 +38,9 @@
  * -- and in the `time_ref = -2` conversion it does, which rounds differently
  * from `INT` on the negative side of the epoch -- `std::floor` is used here.
  *
- * remora_caldate does not return hours, minutes or seconds. ROMS derives them
- * from the day fraction through the tolerant rounding helper in `round_mod`,
- * and half-porting that would be worse than leaving it out; the day fraction is
- * available from remora_caldate's `yday` for a caller that needs it. The
- * reference date does carry a time of day -- `remora.time_ref` can name one --
- * and remora_ref_clock returns it.
+ * The day fraction is available from remora_caldate's `yday` for a caller that
+ * needs it. The reference date does carry a time of day -- `remora.time_ref`
+ * can name one -- and remora_ref_clock returns it.
  *
  * Two quirks of the `time_ref = -2` calendar carry over, both ROMS's and both
  * confirmed against the Fortran rather than inferred:

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -6,3 +6,5 @@ else()
     set(FEXTREMA_EXE ${CMAKE_BINARY_DIR}/Submodules/AMReX/Tools/Plotfile/amrex_fextrema CACHE INTERNAL "Path to fextrema executable for regression tests")
 endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/CTestList.cmake)
+
+add_subdirectory(Unit)

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Unit tests: plain executables that return nonzero on failure, no framework.
+# Each gets the "unit" ctest label, so `ctest -L unit` runs them alone and
+# `ctest -LE unit` skips them.
+set(remora_unit_test_exe_name remora_unit_tests)
+
+add_executable(${remora_unit_test_exe_name}
+  ${CMAKE_CURRENT_SOURCE_DIR}/REMORA_DateClock_test.cpp
+)
+
+target_include_directories(${remora_unit_test_exe_name} PRIVATE
+  ${PROJECT_SOURCE_DIR}/Source/Utils
+)
+
+# AMReX supplies amrex::Real, the inline and GPU qualifiers, and the defines
+# that go with them -- AMREX_USE_FLOAT in particular, which changes which
+# reference dates REMORA_DateClock.H can represent.
+target_link_libraries(${remora_unit_test_exe_name} PRIVATE ${REMORA_AMREX_TARGET})
+
+# AMREX_GPU_HOST_DEVICE expands to __host__ __device__ in a GPU build, so this
+# has to go through the device compiler, as Source/ does.
+if (REMORA_ENABLE_CUDA)
+  setup_target_for_cuda_compilation(${remora_unit_test_exe_name})
+endif ()
+
+add_test(NAME DateClock COMMAND ${remora_unit_test_exe_name})
+set_tests_properties(DateClock PROPERTIES
+  TIMEOUT 60
+  LABELS "unit"
+)

--- a/Tests/Unit/REMORA_DateClock_test.cpp
+++ b/Tests/Unit/REMORA_DateClock_test.cpp
@@ -1,0 +1,414 @@
+/**
+ * \file REMORA_DateClock_test.cpp
+ *
+ * Unit tests for Source/Utils/REMORA_DateClock.H, REMORA's port of ROMS
+ * `dateclock.F`.
+ *
+ * Every expectation comes from outside the implementation, so a failure means
+ * the port is wrong rather than that it changed:
+ *
+ *   - Proleptic Gregorian day numbers are Matlab `datenum` values; ROMS
+ *     documents its calendar as matching Matlab's.
+ *   - The anchors -- `datenum(0001,01,01) = 367`, `datenum(1968,05,23) =
+ *     2440000`, the 360_day pair -- are the values `dateclock.F` states in its
+ *     own comments.
+ *   - Reference dates and calendar names come off the four branches of ROMS
+ *     `ref_clock`.
+ *   - Days of the year are Gregorian arithmetic.
+ *   - The round-trip checks are properties rather than tables: `datevec` must
+ *     invert `datenum`, which needs no authority at all.
+ *
+ * A `yyyymmdd.dd` reference date needs eight exact digits and cannot survive a
+ * single-precision Real, so cases passing one are gated on
+ * remora_time_ref_is_representable. The sentinel calendars (0, -1, -2) are small
+ * integers and run in either precision.
+ */
+
+#include "REMORA_DateClock.H"
+
+#include <cstdio>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+int failures = 0;
+int checks = 0;
+
+void check_int (const char* what, int got, int expect)
+{
+    ++checks;
+    if (got != expect) {
+        ++failures;
+        std::printf("FAIL %s: got %d, expected %d\n", what, got, expect);
+    }
+}
+
+//! Exact comparison is deliberate: every value asserted below is an integer or
+//! half-integer well inside 2^24, representable in either precision, so the
+//! port should reproduce it bit for bit rather than nearly.
+void check_real (const char* what, amrex::Real got, amrex::Real expect)
+{
+    ++checks;
+    if (got != expect) {
+        ++failures;
+        std::printf("FAIL %s: got %.6f, expected %.6f\n", what,
+                    static_cast<double>(got), static_cast<double>(expect));
+    }
+}
+
+void check_str (const char* what, const std::string& got, const std::string& expect)
+{
+    ++checks;
+    if (got != expect) {
+        ++failures;
+        std::printf("FAIL %s: got \"%s\", expected \"%s\"\n", what,
+                    got.c_str(), expect.c_str());
+    }
+}
+
+void check_date (const char* what, amrex::Real time_ref, int year, int month, int day)
+{
+    int y = 0;
+    int m = 0;
+    int d = 0;
+    remora_datevec(time_ref, remora_datenum(time_ref, year, month, day), true, y, m, d);
+    ++checks;
+    if ((y != year) || (m != month) || (d != day)) {
+        ++failures;
+        std::printf("FAIL %s: %04d-%02d-%02d round-tripped to %04d-%02d-%02d\n",
+                    what, year, month, day, y, m, d);
+    }
+}
+
+//! Whether a yyyymmdd.dd reference date can be used at this precision.
+bool dates_representable ()
+{
+    return remora_time_ref_is_representable(amrex::Real(20200101.0));
+}
+
+/** Day of the year. ROMS `yearday`. */
+void test_yearday ()
+{
+    check_int("yearday(2020,01,01)", remora_yearday(2020, 1, 1), 1);
+    check_int("yearday(2024,02,29)", remora_yearday(2024, 2, 29), 60);
+    check_int("yearday(2024,03,01)", remora_yearday(2024, 3, 1), 61);
+    check_int("yearday(2023,03,01)", remora_yearday(2023, 3, 1), 60);
+    check_int("yearday(2024,12,31)", remora_yearday(2024, 12, 31), 366);
+    check_int("yearday(2023,12,31)", remora_yearday(2023, 12, 31), 365);
+
+    // 1900 is not a leap year and 2000 is: the century rules, not just the
+    // four-year one.
+    check_int("yearday(1900,03,01)", remora_yearday(1900, 3, 1), 60);
+    check_int("yearday(2000,03,01)", remora_yearday(2000, 3, 1), 61);
+}
+
+/** Calendar date to day number. ROMS `datenum`. */
+void test_datenum ()
+{
+    const amrex::Real greg = amrex::Real(0.0);
+
+    // dateclock.F's own reference values for this calendar.
+    check_real("datenum(0000,01,01)", remora_datenum(greg, 0, 1, 1), amrex::Real(1.0));
+    check_real("datenum(0001,01,01)", remora_datenum(greg, 1, 1, 1), amrex::Real(367.0));
+
+    // Matlab datenum.
+    check_real("datenum(2000,01,01)", remora_datenum(greg, 2000, 1, 1),
+               amrex::Real(730486.0));
+    check_real("datenum(2020,01,01)", remora_datenum(greg, 2020, 1, 1),
+               amrex::Real(737791.0));
+    check_real("datenum(2024,02,29)", remora_datenum(greg, 2024, 2, 29),
+               amrex::Real(739311.0));
+
+    // The day fraction is hours/24 + minutes/1440 + seconds/86400.
+    check_real("datenum(2020,01,01,12:00:00)",
+               remora_datenum(greg, 2020, 1, 1, 12, 0, amrex::Real(0.0)),
+               amrex::Real(737791.5));
+    check_real("datenum(2020,01,01,06:00:00)",
+               remora_datenum(greg, 2020, 1, 1, 6, 0, amrex::Real(0.0)),
+               amrex::Real(737791.25));
+
+    // 360_day: twelve 30-day months, no leap years. dateclock.F's values.
+    const amrex::Real day360 = amrex::Real(-1.0);
+    check_real("datenum(0000,01,01) [360_day]", remora_datenum(day360, 0, 1, 1),
+               amrex::Real(0.0));
+    check_real("datenum(0001,01,01) [360_day]", remora_datenum(day360, 1, 1, 1),
+               amrex::Real(360.0));
+    check_real("datenum(2020,01,01) [360_day]", remora_datenum(day360, 2020, 1, 1),
+               amrex::Real(727200.0));   // 2020 * 360
+
+    // Truncated Julian day. dateclock.F documents datenum(1968,05,23) = 2440000.
+    check_real("datenum(1968,05,23) [trunc Julian]",
+               remora_datenum(amrex::Real(-2.0), 1968, 5, 23), amrex::Real(2440000.0));
+}
+
+/** Day number of the reference date. ROMS `ref_clock`'s `Rclock%DateNumber(1)`. */
+void test_ref_datenum ()
+{
+    // The three sentinel calendars, as dateclock.F hardcodes them.
+    check_real("ref_datenum(0)", remora_ref_datenum(amrex::Real(0.0)),
+               amrex::Real(367.0));       // 0001-01-01
+    check_real("ref_datenum(-1)", remora_ref_datenum(amrex::Real(-1.0)),
+               amrex::Real(359.0));       // 0000-12-30, 360_day
+    check_real("ref_datenum(-2)", remora_ref_datenum(amrex::Real(-2.0)),
+               amrex::Real(2440000.0));   // 1968-05-23, truncated Julian
+
+    if (!dates_representable()) {
+        return;
+    }
+
+    // A yyyymmdd.dd date must decode to the same day number as naming its
+    // fields outright.
+    check_real("ref_datenum(20200101)", remora_ref_datenum(amrex::Real(20200101.0)),
+               amrex::Real(737791.0));
+    check_real("ref_datenum(20200101.5)", remora_ref_datenum(amrex::Real(20200101.5)),
+               amrex::Real(737791.5));
+    check_real("ref_datenum(20000101)", remora_ref_datenum(amrex::Real(20000101.0)),
+               amrex::Real(730486.0));
+    check_real("ref_datenum(19680523)", remora_ref_datenum(amrex::Real(19680523.0)),
+               amrex::Real(718941.0));    // Matlab datenum(1968,5,23)
+
+    // ROMS clamps a month or day of zero up to 1, so these are all 0001-01-01.
+    check_real("ref_datenum(101)", remora_ref_datenum(amrex::Real(101.0)),
+               amrex::Real(367.0));
+    check_real("ref_datenum(10101)", remora_ref_datenum(amrex::Real(10101.0)),
+               amrex::Real(367.0));
+}
+
+/** `datevec` must invert `datenum` over the range a model run can reach. */
+void test_datevec_roundtrip ()
+{
+    // Proleptic Gregorian, not extended below the 1582 changeover: the header
+    // documents that datevec reads a small day number as a truncated Julian one
+    // when time_ref = -2, and that datenum(0,0,0) = 0 is a special case.
+    const amrex::Real greg = amrex::Real(0.0);
+    for (int year = 1900; year <= 2100; year += 7) {
+        for (int month = 1; month <= 12; ++month) {
+            check_date("roundtrip [gregorian]", greg, year, month, 1);
+            check_date("roundtrip [gregorian]", greg, year, month, 15);
+            check_date("roundtrip [gregorian]", greg, year, month, 28);
+        }
+    }
+    check_date("roundtrip 2024-02-29", greg, 2024, 2, 29);
+    check_date("roundtrip 2000-02-29", greg, 2000, 2, 29);
+    check_date("roundtrip 2024-12-31", greg, 2024, 12, 31);
+
+    // 360_day, where every month has 30 days.
+    const amrex::Real day360 = amrex::Real(-1.0);
+    for (int year = 1900; year <= 2100; year += 7) {
+        for (int month = 1; month <= 12; ++month) {
+            check_date("roundtrip [360_day]", day360, year, month, 1);
+            check_date("roundtrip [360_day]", day360, year, month, 30);
+        }
+    }
+
+    // Truncated Julian, modern dates only.
+    const amrex::Real julian = amrex::Real(-2.0);
+    for (int year = 1900; year <= 2100; year += 7) {
+        for (int month = 1; month <= 12; ++month) {
+            check_date("roundtrip [trunc Julian]", julian, year, month, 1);
+            check_date("roundtrip [trunc Julian]", julian, year, month, 28);
+        }
+    }
+}
+
+/** Model time to calendar date. ROMS `caldate`. */
+void test_caldate ()
+{
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    amrex::Real yday = amrex::Real(0.0);
+
+    // Model time zero is the reference date itself: 0001-01-01 for time_ref = 0.
+    remora_caldate(amrex::Real(0.0), amrex::Real(0.0), year, month, day, yday);
+    check_int("caldate(0, 0 d) year", year, 1);
+    check_int("caldate(0, 0 d) month", month, 1);
+    check_int("caldate(0, 0 d) day", day, 1);
+    check_real("caldate(0, 0 d) yday", yday, amrex::Real(1.0));
+
+    // 737424 days past 0001-01-01 is 1 January 2020 -- the number
+    // remora.start_time = 63713433600 puts in the dstart output variable, so
+    // this case ties that documented input to the calendar.
+    remora_caldate(amrex::Real(0.0), amrex::Real(737424.0), year, month, day, yday);
+    check_int("caldate(0, 737424 d) year", year, 2020);
+    check_int("caldate(0, 737424 d) month", month, 1);
+    check_int("caldate(0, 737424 d) day", day, 1);
+    check_real("caldate(0, 737424 d) yday", yday, amrex::Real(1.0));
+
+    // Half a day in, the date is unchanged and yday carries the fraction.
+    remora_caldate(amrex::Real(0.0), amrex::Real(737424.5), year, month, day, yday);
+    check_int("caldate(0, 737424.5 d) day", day, 1);
+    check_real("caldate(0, 737424.5 d) yday", yday, amrex::Real(1.5));
+
+    // A leap day reached from the reference date, not named directly:
+    // datenum(2024,2,29) - datenum(0001,01,01) = 739311 - 367.
+    remora_caldate(amrex::Real(0.0), amrex::Real(738944.0), year, month, day, yday);
+    check_int("caldate(0, 738944 d) year", year, 2024);
+    check_int("caldate(0, 738944 d) month", month, 2);
+    check_int("caldate(0, 738944 d) day", day, 29);
+    check_real("caldate(0, 738944 d) yday", yday, amrex::Real(60.0));
+
+    // 360_day. The epoch is 0000-12-30: ROMS shifts it back a day so day number
+    // 0 lands on 01-Jan-0000, undoing a historical offset. So model time 1 day
+    // is 0001-01-01 -- not 0, and not 360.
+    remora_caldate(amrex::Real(-1.0), amrex::Real(1.0), year, month, day, yday);
+    check_int("caldate(-1, 1 d) year", year, 1);
+    check_int("caldate(-1, 1 d) month", month, 1);
+    check_int("caldate(-1, 1 d) day", day, 1);
+    check_real("caldate(-1, 1 d) yday", yday, amrex::Real(1.0));
+
+    // A year on. Every month has 30 days, so the last day of the year is the
+    // 30th of the twelfth and yday is exactly 360.
+    remora_caldate(amrex::Real(-1.0), amrex::Real(360.0), year, month, day, yday);
+    check_int("caldate(-1, 360 d) year", year, 1);
+    check_int("caldate(-1, 360 d) month", month, 12);
+    check_int("caldate(-1, 360 d) day", day, 30);
+    check_real("caldate(-1, 360 d) yday", yday, amrex::Real(360.0));
+
+    // The two-argument form must agree with the six-argument one.
+    int year2 = 0;
+    amrex::Real yday2 = amrex::Real(0.0);
+    remora_caldate(amrex::Real(0.0), amrex::Real(737424.0), year2, yday2);
+    check_int("caldate 2-arg year", year2, 2020);
+    check_real("caldate 2-arg yday", yday2, amrex::Real(1.0));
+}
+
+/** The reference date behind `Rclock%string`. ROMS `ref_clock`. */
+void test_ref_clock ()
+{
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+
+    // time_ref = 0: proleptic Gregorian from 0001-01-01 00:00:00.
+    remora_ref_clock(amrex::Real(0.0), year, month, day, hour, minute, second);
+    check_int("ref_clock(0) year", year, 1);
+    check_int("ref_clock(0) month", month, 1);
+    check_int("ref_clock(0) day", day, 1);
+    check_int("ref_clock(0) hour", hour, 0);
+    check_int("ref_clock(0) minute", minute, 0);
+    check_int("ref_clock(0) second", second, 0);
+
+    // time_ref = -1: 360_day, epoch shifted back a day to 0000-12-30.
+    remora_ref_clock(amrex::Real(-1.0), year, month, day, hour, minute, second);
+    check_int("ref_clock(-1) year", year, 0);
+    check_int("ref_clock(-1) month", month, 12);
+    check_int("ref_clock(-1) day", day, 30);
+
+    // time_ref = -2: truncated Julian day from 1968-05-23.
+    remora_ref_clock(amrex::Real(-2.0), year, month, day, hour, minute, second);
+    check_int("ref_clock(-2) year", year, 1968);
+    check_int("ref_clock(-2) month", month, 5);
+    check_int("ref_clock(-2) day", day, 23);
+
+    if (!dates_representable()) {
+        return;
+    }
+
+    remora_ref_clock(amrex::Real(20200101.0), year, month, day, hour, minute, second);
+    check_int("ref_clock(20200101) year", year, 2020);
+    check_int("ref_clock(20200101) month", month, 1);
+    check_int("ref_clock(20200101) day", day, 1);
+    check_int("ref_clock(20200101) hour", hour, 0);
+
+    // The fractional part is a time of day: .5 is 12:00, as dateclock.F's
+    // "20020115.5 for 15 Jan 2002, 12:0:0" states.
+    remora_ref_clock(amrex::Real(20200101.5), year, month, day, hour, minute, second);
+    check_int("ref_clock(20200101.5) day", day, 1);
+    check_int("ref_clock(20200101.5) hour", hour, 12);
+    check_int("ref_clock(20200101.5) minute", minute, 0);
+    check_int("ref_clock(20200101.5) second", second, 0);
+
+    remora_ref_clock(amrex::Real(20250908.25), year, month, day, hour, minute, second);
+    check_int("ref_clock(20250908.25) year", year, 2025);
+    check_int("ref_clock(20250908.25) month", month, 9);
+    check_int("ref_clock(20250908.25) day", day, 8);
+    check_int("ref_clock(20250908.25) hour", hour, 6);
+}
+
+/** The CF time-units strings. ROMS `Rclock%string` and `Rclock%calendar`. */
+void test_ref_strings ()
+{
+    check_str("ref_date_string(0)", remora_ref_date_string(amrex::Real(0.0)),
+              "0001-01-01 00:00:00");
+    check_str("ref_date_string(-1)", remora_ref_date_string(amrex::Real(-1.0)),
+              "0000-12-30 00:00:00");
+    check_str("ref_date_string(-2)", remora_ref_date_string(amrex::Real(-2.0)),
+              "1968-05-23 00:00:00");
+
+    // ref_clock assigns proleptic_gregorian to both non-negative branches.
+    check_str("ref_calendar(0)", remora_ref_calendar(amrex::Real(0.0)),
+              "proleptic_gregorian");
+    check_str("ref_calendar(-1)", remora_ref_calendar(amrex::Real(-1.0)), "360_day");
+    check_str("ref_calendar(-2)", remora_ref_calendar(amrex::Real(-2.0)), "gregorian");
+
+    if (!dates_representable()) {
+        return;
+    }
+
+    check_str("ref_date_string(20200101)",
+              remora_ref_date_string(amrex::Real(20200101.0)), "2020-01-01 00:00:00");
+    check_str("ref_date_string(20200101.5)",
+              remora_ref_date_string(amrex::Real(20200101.5)), "2020-01-01 12:00:00");
+    check_str("ref_date_string(20250908.25)",
+              remora_ref_date_string(amrex::Real(20250908.25)), "2025-09-08 06:00:00");
+    check_str("ref_calendar(20200101)",
+              remora_ref_calendar(amrex::Real(20200101.0)), "proleptic_gregorian");
+}
+
+/** The two guards on remora.time_ref. */
+void test_time_ref_validation ()
+{
+    check_int("is_valid(0)", remora_time_ref_is_valid(amrex::Real(0.0)) ? 1 : 0, 1);
+    check_int("is_valid(-1)", remora_time_ref_is_valid(amrex::Real(-1.0)) ? 1 : 0, 1);
+    check_int("is_valid(-2)", remora_time_ref_is_valid(amrex::Real(-2.0)) ? 1 : 0, 1);
+    check_int("is_valid(20200101)",
+              remora_time_ref_is_valid(amrex::Real(20200101.0)) ? 1 : 0, 1);
+
+    // ROMS's calendar if-chain has no final ELSE, so anything below -2 names no
+    // calendar and has to be rejected up front.
+    check_int("is_valid(-3)", remora_time_ref_is_valid(amrex::Real(-3.0)) ? 1 : 0, 0);
+    check_int("is_valid(-100)", remora_time_ref_is_valid(amrex::Real(-100.0)) ? 1 : 0, 0);
+
+    // The sentinels are small integers and are always exact.
+    check_int("is_representable(0)",
+              remora_time_ref_is_representable(amrex::Real(0.0)) ? 1 : 0, 1);
+    check_int("is_representable(-1)",
+              remora_time_ref_is_representable(amrex::Real(-1.0)) ? 1 : 0, 1);
+    check_int("is_representable(-2)",
+              remora_time_ref_is_representable(amrex::Real(-2.0)) ? 1 : 0, 1);
+
+    // A yyyymmdd.dd date needs eight exact digits, so it survives double and
+    // not float.
+    const int expect_date = std::is_same<amrex::Real, double>::value ? 1 : 0;
+    check_int("is_representable(20200101)",
+              remora_time_ref_is_representable(amrex::Real(20200101.0)) ? 1 : 0,
+              expect_date);
+}
+
+} // namespace
+
+int main ()
+{
+    test_yearday();
+    test_datenum();
+    test_ref_datenum();
+    test_datevec_roundtrip();
+    test_caldate();
+    test_ref_clock();
+    test_ref_strings();
+    test_time_ref_validation();
+
+    if (failures > 0) {
+        std::printf("REMORA_DateClock: %d of %d checks FAILED\n", failures, checks);
+        return 1;
+    }
+
+    std::printf("REMORA_DateClock: all %d checks passed%s\n", checks,
+                dates_representable() ? "" : " (yyyymmdd dates skipped: single precision)");
+    return 0;
+}


### PR DESCRIPTION
Fixes #662.

## Summary

Every NetCDF history file and plotfile carried a `start_time` global attribute read
from a member that was never assigned, so the attribute held a different indeterminate
value on every run and varied with rank count. The attribute and the member are removed.

The simulation start time now goes out as ROMS does, in a scalar variable `dstart`.
Fixing it surfaced a second defect: `ocean_time`'s hardcoded units were wrong for any
run with `remora.time_ref` set. Both time stamps now take their reference date and
calendar from it.

Metadata only — no field data moves, and no gold file is touched.

## Problem

**`start_time` was undefined behavior.** `REMORA::start_bdy_time` was declared with no
initializer, and `aef1964` ("remove old boundary reading function") deleted
`REMORA_ReadFromBdryNetcdf.cpp`, which held its only assignment. The declaration and
the one read survived; the write did not. That read was

```cpp
ncf.put_attr("start_time", std::vector<double> { start_bdy_time });
```

so an indeterminate value was published to every NetCDF output file. #662 records five
runs of the same case producing five different denormals, the last on unmodified
`development`, with the value also shifting with rank count.

**`ocean_time`'s units named the wrong epoch.** They were the string literal
`"seconds since 0001-01-01 00:00:00"`, which is the epoch of `time_ref = 0` only. A run
with `remora.time_ref = 20200101` wrote seconds measured from 2020 while claiming they
were measured from year 1 — off by 737424 days, with nothing in the file to say so. It
went unnoticed until `dstart` gave the file a second time stamp to disagree with.

## Changes

**`Source/IO/REMORA_NCPlotFile.cpp`.** The `start_time` attribute is gone. In its place
a scalar `dstart`, following ROMS `def_info`: `long_name` "time stamp assigned to model
initialization", units of `days since <reference date>`, and a `calendar` attribute.
The value is `remora.start_time / 86400`, which makes `ocean_time = dstart * 86400 +
elapsed` — the relation ROMS's own output satisfies. Both time stamps take that
reference date and calendar from `remora.time_ref`.

`dstart` is `NC_DOUBLE` rather than `NCDType::Real` like the fields around it. Days
since year 1 is a six-digit number, so a single-precision build would round the model's
start to the nearest hour or worse. ROMS keeps `DSTART` in double for the same reason.

**`Source/Utils/REMORA_DateClock.H`.** Producing those two strings is ROMS `ref_clock`,
which the header already carried a fragment of. Its date decode is split out as
`remora_ref_clock`, and two host-only helpers join it: `remora_ref_calendar` for
`Rclock%calendar` and `remora_ref_date_string` for `Rclock%string`.
`remora_ref_datenum` now calls `remora_ref_clock` instead of repeating the
`yyyymmdd.dd` arithmetic.

**Dead code.** `start_bdy_time` and `bdy_time_interval` are removed from `REMORA.H`,
along with the `#if 0` block in `FillCoarsePatchMap` that was `bdy_time_interval`'s only
mention. #662 asks for this in the same pass; that block also declares `ctime` twice and
would not compile if it were ever re-enabled.

**Tests.** `Tests/Unit/` is new, with its wiring and a `testing.rst` section on the
pattern. The dead `add_test_u` in `CTestList.cmake` — an amr-wind leftover naming an
undefined `amr_wind_unit_test_exe_name`, never invoked — wants removing, but not here.

`Inputs.rst` documents `dstart` in the existing reference-date section.

## Backwards compatibility

**The `start_time` global attribute no longer exists.** Nothing in the tree read it, and
nothing outside can have depended on its *value* — it never held one. A downstream
reader that requires the attribute to be present will not find it.

**`ocean_time:units` changes for a run with `remora.time_ref` set,** from wrong to right.
At the default `time_ref = 0` the string is byte-identical to before.

**`ocean_time:calendar` is new,** as is the `dstart` variable.

## Verification

**There is now a unit test for the date clock,** the first in the tree:
`Tests/Unit/REMORA_DateClock_test.cpp`, 2535 checks, registered as the ctest lane
`DateClock` under a new `unit` label. Expectations come from outside the
implementation — Matlab `datenum` values, the anchors ROMS `dateclock.F` states in its
own comments, calendar names off the four branches of `ref_clock`, Gregorian arithmetic
— plus round-trip properties asserting `datevec` inverts `datenum`, which need no
authority at all. Writing it caught one thing, in the test rather than the code: the
`time_ref = -1` epoch is 0000-12-**30**, so model time 1 day is 0001-01-01, not 0 and
not 360. That shift is ROMS's, and is now pinned.

**The refactor is bit-for-bit.** Two checks against the pre-refactor header, taken from
`fad39da`:

- The unit test's shared-API subset — everything but the three new functions — compiles
  and passes identically against both headers: 2501 checks, no failures either side.
- A value dump over a wide sweep (every reference-date decode, `datenum`, `datevec` in
  both day and second units, `caldate`, `yearday`, both guards, across all three
  calendars) is byte-identical between them: 457,094 lines, `diff` clean.

**32/32 ctests pass,** and the build is clean with no new warnings.

**Output checked by hand with `ncmpidump`,** since no ctest exercises the NetCDF writer:

| `remora.time_ref` | `remora.start_time` | `dstart` | units of `dstart` | `calendar` |
|---|---|---|---|---|
| `0` (default) | `0` | `0` | days since 0001-01-01 00:00:00 | proleptic_gregorian |
| `0` | `63713433600` | `737424` | days since 0001-01-01 00:00:00 | proleptic_gregorian |
| `20200101` | `0` | `0` | days since 2020-01-01 00:00:00 | proleptic_gregorian |
| `20200101.5` | `86400` | `1` | days since 2020-01-01 12:00:00 | proleptic_gregorian |
| `-1` | `0` | `0` | days since 0000-12-30 00:00:00 | 360_day |
| `-2` | `0` | `0` | days since 1968-05-23 00:00:00 | gregorian |

Row 2 uses the `start_time` `Inputs.rst` documents for 1 January 2020, and 737424 days
after 0001-01-01 is exactly that date — docs and code agree.

**The reported symptom is gone.** That same case at 1, 4, and 8 ranks gives
`dstart = 737424` every time, and `start_time` appears nowhere in any header.

**`ocean_time = dstart * 86400 + elapsed` holds:** after ten 300-second steps from
`start_time = 63713433600`, `ocean_time = 63713436600`.

**Both writers carry it** — the history file, whose header is written once, and the
per-step plotfile, which writes one per file.

## Notes for the reviewer

**#662 offered three options; this is the middle one, re-pointed.** The issue notes that
"the boundary start time" is no longer well defined, since `1aee268` moved the time axis
into per-series `NCTimeSeriesBoundary::bry_times` and allowed a different one per
variable. So rather than pick a series arbitrarily, the attribute is replaced by the
quantity a reader of a history file actually wants and ROMS actually writes: when the
run starts.

**No ctest covers the NetCDF writer.** The hand verification above is the only check on
the emitted metadata. A lane that dumps a header and diffs it against a fixture would
have caught both defects here, and is worth adding.
